### PR TITLE
Endurance DOFSTK,FLORTK,PARADK calfiles

### DIFF
--- a/calibration/DOFSTK/CGINS-DOFSTK-02496__20200219.csv
+++ b/calibration/DOFSTK/CGINS-DOFSTK-02496__20200219.csv
@@ -1,0 +1,7 @@
+serial,name,value,notes
+43-2496,CC_frequency_offset,-8.241945e+002,date in filename comes from Soc-adjusted caldate
+43-2496,CC_oxygen_signal_slope,3.3179e-004,this is the adjusted Soc (O2 signal slope) value
+43-2496,CC_residual_temperature_correction_factor_a,-5.403788e-003,
+43-2496,CC_residual_temperature_correction_factor_b,1.931956e-004,
+43-2496,CC_residual_temperature_correction_factor_c,-2.440793e-006,
+43-2496,CC_residual_temperature_correction_factor_e,3.600000e-002,

--- a/calibration/FLORTK/CGINS-FLORTK-01707__20191210.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01707__20191210.csv
@@ -1,0 +1,11 @@
+serial,name,value,notes
+1707,CC_dark_counts_cdom,50,date in filename comes from dev file
+1707,CC_scale_factor_cdom,0.0895,
+1707,CC_dark_counts_chlorophyll_a,50,
+1707,CC_scale_factor_chlorophyll_a,0.0116,
+1707,CC_dark_counts_volume_scatter,49,
+1707,CC_scale_factor_volume_scatter,3.663e-06,
+1707,CC_depolarization_ratio,0.039,Constant
+1707,CC_measurement_wavelength,700,[nm]; Constant
+1707,CC_scattering_angle,124,[degrees]; Constant
+1707,CC_angular_resolution,1.076,Erroneously named constant; this coefficient scales the particulate scattering at 124 degrees to total backscatter from particles

--- a/calibration/PARADK/CGINS-PARADK-20438__20191203.csv
+++ b/calibration/PARADK/CGINS-PARADK-20438__20191203.csv
@@ -1,0 +1,3 @@
+serial,name,value,notes
+20438,CC_dark_offset,1.2,probe dark [mV]
+20438,CC_scale_wet,9.25e-18,[V/(quanta/cm2-sec)]


### PR DESCRIPTION
Planned for Endurance 13, CE09OSPM_00013.

The adjusted SOC value for the DOFSTK calibration was omitted from the original documentation from Seabird. This value comes from the test template requested from and sent by Seabird. The adjusted SOC determination was done on the same day as the overall DOFSTK calibration. 