### PR TITLE
FLORT-D Cal Files

### DIFF
--- a/calibration/FLORTD/CGINS-FLORTD-00995__20230726.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00995__20230726.csv
@@ -1,0 +1,11 @@
+serial,name,value,notes
+995,CC_dark_counts_cdom,49,date in filename comes from dev file
+995,CC_scale_factor_cdom,1.128E-01,
+995,CC_dark_counts_chlorophyll_a,48,
+995,CC_scale_factor_chlorophyll_a,1.159E-02,
+995,CC_dark_counts_volume_scatter,50.75,
+995,CC_scale_factor_volume_scatter,1.849E-06,
+995,CC_depolarization_ratio,0.039,Constant
+995,CC_measurement_wavelength,700,[nm]; Constant
+995,CC_scattering_angle,124,[degrees]; Constant
+995,CC_angular_resolution,1.076,Erroneously named constant; this coefficient scales the particulate scattering at 124 degrees to total backscatter from particles

--- a/calibration/FLORTD/CGINS-FLORTD-01123__20230727.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01123__20230727.csv
@@ -1,0 +1,11 @@
+serial,name,value,notes
+1123,CC_dark_counts_cdom,50.15,date in filename comes from dev file
+1123,CC_scale_factor_cdom,9.139E-02,
+1123,CC_dark_counts_chlorophyll_a,51.1,
+1123,CC_scale_factor_chlorophyll_a,1.206E-02,
+1123,CC_dark_counts_volume_scatter,52.625,
+1123,CC_scale_factor_volume_scatter,1.846E-06,
+1123,CC_depolarization_ratio,0.039,Constant
+1123,CC_measurement_wavelength,700,[nm]; Constant
+1123,CC_scattering_angle,124,[degrees]; Constant
+1123,CC_angular_resolution,1.076,Erroneously named constant; this coefficient scales the particulate scattering at 124 degrees to total backscatter from particles

--- a/calibration/FLORTD/CGINS-FLORTD-01152__20230726.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01152__20230726.csv
@@ -1,0 +1,11 @@
+serial,name,value,notes
+1152,CC_dark_counts_cdom,49,date in filename comes from dev file
+1152,CC_scale_factor_cdom,9.061E-02,
+1152,CC_dark_counts_chlorophyll_a,47,
+1152,CC_scale_factor_chlorophyll_a,7.256E-03,
+1152,CC_dark_counts_volume_scatter,45.54716981,
+1152,CC_scale_factor_volume_scatter,1.841E-06,
+1152,CC_depolarization_ratio,0.039,Constant
+1152,CC_measurement_wavelength,700,[nm]; Constant
+1152,CC_scattering_angle,124,[degrees]; Constant
+1152,CC_angular_resolution,1.076,Erroneously named constant; this coefficient scales the particulate scattering at 124 degrees to total backscatter from particles

--- a/calibration/FLORTD/CGINS-FLORTD-01155__20230724.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01155__20230724.csv
@@ -1,0 +1,11 @@
+serial,name,value,notes
+1155,CC_dark_counts_cdom,45,date in filename comes from dev file
+1155,CC_scale_factor_cdom,9.588E-02,
+1155,CC_dark_counts_chlorophyll_a,52,
+1155,CC_scale_factor_chlorophyll_a,7.260E-03,
+1155,CC_dark_counts_volume_scatter,49.225,
+1155,CC_scale_factor_volume_scatter,1.857E-06,
+1155,CC_depolarization_ratio,0.039,Constant
+1155,CC_measurement_wavelength,700,[nm]; Constant
+1155,CC_scattering_angle,124,[degrees]; Constant
+1155,CC_angular_resolution,1.076,Erroneously named constant; this coefficient scales the particulate scattering at 124 degrees to total backscatter from particles

--- a/calibration/FLORTD/CGINS-FLORTD-01197__20230727.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01197__20230727.csv
@@ -1,0 +1,11 @@
+serial,name,value,notes
+1197,CC_dark_counts_cdom,48,date in filename comes from dev file
+1197,CC_scale_factor_cdom,9.081E-02,
+1197,CC_dark_counts_chlorophyll_a,48,
+1197,CC_scale_factor_chlorophyll_a,1.210E-02,
+1197,CC_dark_counts_volume_scatter,45.675,
+1197,CC_scale_factor_volume_scatter,1.876E-06,
+1197,CC_depolarization_ratio,0.039,Constant
+1197,CC_measurement_wavelength,700,[nm]; Constant
+1197,CC_scattering_angle,124,[degrees]; Constant
+1197,CC_angular_resolution,1.076,Erroneously named constant; this coefficient scales the particulate scattering at 124 degrees to total backscatter from particles

--- a/calibration/FLORTD/CGINS-FLORTD-01290__20230724.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01290__20230724.csv
@@ -1,0 +1,11 @@
+serial,name,value,notes
+1290,CC_dark_counts_cdom,47,date in filename comes from dev file
+1290,CC_scale_factor_cdom,9.138E-02,
+1290,CC_dark_counts_chlorophyll_a,46,
+1290,CC_scale_factor_chlorophyll_a,1.207E-02,
+1290,CC_dark_counts_volume_scatter,49.225,
+1290,CC_scale_factor_volume_scatter,1.773E-06,
+1290,CC_depolarization_ratio,0.039,Constant
+1290,CC_measurement_wavelength,700,[nm]; Constant
+1290,CC_scattering_angle,124,[degrees]; Constant
+1290,CC_angular_resolution,1.076,Erroneously named constant; this coefficient scales the particulate scattering at 124 degrees to total backscatter from particles

--- a/calibration/FLORTD/CGINS-FLORTD-01487__20230727.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01487__20230727.csv
@@ -1,0 +1,11 @@
+serial,name,value,notes
+1487,CC_dark_counts_cdom,49.975,date in filename comes from dev file
+1487,CC_scale_factor_cdom,9.138E-02,
+1487,CC_dark_counts_chlorophyll_a,52.925,
+1487,CC_scale_factor_chlorophyll_a,1.196E-02,
+1487,CC_dark_counts_volume_scatter,50.825,
+1487,CC_scale_factor_volume_scatter,1.885E-06,
+1487,CC_depolarization_ratio,0.039,Constant
+1487,CC_measurement_wavelength,700,[nm]; Constant
+1487,CC_scattering_angle,124,[degrees]; Constant
+1487,CC_angular_resolution,1.076,Erroneously named constant; this coefficient scales the particulate scattering at 124 degrees to total backscatter from particles

--- a/calibration/FLORTD/CGINS-FLORTD-01488__20230728.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01488__20230728.csv
@@ -1,0 +1,11 @@
+serial,name,value,notes
+1488,CC_dark_counts_cdom,48,date in filename comes from dev file
+1488,CC_scale_factor_cdom,9.040E-02,
+1488,CC_dark_counts_chlorophyll_a,50,
+1488,CC_scale_factor_chlorophyll_a,1.206E-02,
+1488,CC_dark_counts_volume_scatter,49.575,
+1488,CC_scale_factor_volume_scatter,1.707E-06,
+1488,CC_depolarization_ratio,0.039,Constant
+1488,CC_measurement_wavelength,700,[nm]; Constant
+1488,CC_scattering_angle,124,[degrees]; Constant
+1488,CC_angular_resolution,1.076,Erroneously named constant; this coefficient scales the particulate scattering at 124 degrees to total backscatter from particles


### PR DESCRIPTION
All vendor docs up on Vault and Alfresco. There was a lot of rounding off of #s between the DEV files and Characterization Sheets, but everything looked rounded correctly. Please confirm this is okay.