### PR TITLE
Updated CDOM scaling factor based on SeaBirds correction table

### DIFF
--- a/calibration/FLORTD/CGINS-FLORTD-00993__20121101.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00993__20121101.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 993,CC_dark_counts_volume_scatter,51,Measured signal output of fluormeter in clean water with black tape over the detector [counts]
 993,CC_depolarization_ratio,0.039,Depolarization ratio [unitless].
 993,CC_measurement_wavelength,700,Optical backscatter measurement wavelength [nm].
-993,CC_scale_factor_cdom,0.0907,Multiplier [ppb counts^-1]
+993,CC_scale_factor_cdom,0.1514559879160404,New cdom scaling factor = old scaling factor (0.0907) * scaling factor (5.62) * correction factor (0.2971274977067264)
 993,CC_scale_factor_chlorophyll_a,0.0121,Multiplier [ug L^-1 counts^-1]
 993,CC_scale_factor_volume_scatter,1.814e-06,Multiplier [m^-1 sr^-1 counts^-1]
 993,CC_scattering_angle,124,Optical backscatter scattering angle [degrees].

--- a/calibration/FLORTD/CGINS-FLORTD-00993__20160112.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00993__20160112.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 993,CC_dark_counts_volume_scatter,43,Measured signal output of fluormeter in clean water with black tape over the detector [counts]
 993,CC_depolarization_ratio,0.039,Depolarization ratio [unitless].
 993,CC_measurement_wavelength,700,Optical backscatter measurement wavelength [nm].
-993,CC_scale_factor_cdom,0.086,Multiplier [ppb counts^-1]
+993,CC_scale_factor_cdom,0.1384191354407446,New cdom scaling factor = old scaling factor (0.086) * scaling factor (5.62) * correction factor (0.28639231863102)
 993,CC_scale_factor_chlorophyll_a,0.012,Multiplier [ug L^-1 counts^-1]
 993,CC_scale_factor_volume_scatter,0.000001865,Multiplier [m^-1 sr^-1 counts^-1]
 993,CC_scattering_angle,124,Optical backscatter scattering angle [degrees].

--- a/calibration/FLORTD/CGINS-FLORTD-00993__20160608.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00993__20160608.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 993,CC_dark_counts_volume_scatter,46,
 993,CC_depolarization_ratio,0.039,Constant
 993,CC_measurement_wavelength,700,Constant
-993,CC_scale_factor_cdom,9.62E-02,
+993,CC_scale_factor_cdom,0.1548362887139492,New cdom scaling factor = old scaling factor (0.0962) * scaling factor (5.62) * correction factor (0.28639231863102)
 993,CC_scale_factor_chlorophyll_a,0.0118,
 993,CC_scale_factor_volume_scatter,1.754E-06,
 993,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-00993__20170802.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00993__20170802.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 993,CC_dark_counts_volume_scatter,45,
 993,CC_depolarization_ratio,0.039,Constant
 993,CC_measurement_wavelength,700,Constant
-993,CC_scale_factor_cdom,0.0798,
+993,CC_scale_factor_cdom,0.1284400814903653,New cdom scaling factor = old scaling factor (0.0798) * scaling factor (5.62) * correction factor (0.28639231863102)
 993,CC_scale_factor_chlorophyll_a,0.0116,
 993,CC_scale_factor_volume_scatter,2.181E-06,
 993,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-00993__20220202.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00993__20220202.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 993,CC_dark_counts_volume_scatter,90,
 993,CC_depolarization_ratio,0.039,Constant
 993,CC_measurement_wavelength,700,Constant
-993,CC_scale_factor_cdom,9.030E-02,
+993,CC_scale_factor_cdom,0.384782452765018,New cdom scaling factor = old scaling factor (0.0903) * scaling factor (5.62) * correction factor (0.7582129413718173)
 993,CC_scale_factor_chlorophyll_a,1.140E-02,
 993,CC_scale_factor_volume_scatter,2.325E-06,
 993,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-00994__20121101.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00994__20121101.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 994,CC_dark_counts_volume_scatter,50,
 994,CC_depolarization_ratio,0.039,
 994,CC_measurement_wavelength,700,
-994,CC_scale_factor_cdom,0.0906,
+994,CC_scale_factor_cdom,0.1512890022623293,New cdom scaling factor = old scaling factor (0.0906) * scaling factor (5.62) * correction factor (0.2971274977067264)
 994,CC_scale_factor_chlorophyll_a,0.0121,
 994,CC_scale_factor_volume_scatter,1.907e-06,
 994,CC_scattering_angle,124,

--- a/calibration/FLORTD/CGINS-FLORTD-00994__20150317.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00994__20150317.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 994,CC_dark_counts_volume_scatter,46,
 994,CC_depolarization_ratio,0.039,Constant
 994,CC_measurement_wavelength,700,Constant
-994,CC_scale_factor_cdom,0.0898,
+994,CC_scale_factor_cdom,0.1118841150914413,New cdom scaling factor = old scaling factor (0.0898) * scaling factor (5.62) * correction factor (0.2216949391123044)
 994,CC_scale_factor_chlorophyll_a,0.012,
 994,CC_scale_factor_volume_scatter,1.948e-06,
 994,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-00994__20160107.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00994__20160107.csv
@@ -6,7 +6,7 @@ serial,name,value,notes
 Use CTD data from GI01SUMO-SBD11-06-METBKA000 or GI01SUMO-SBD12-06-METBKA000."
 994,CC_depolarization_ratio,0.039,Constant
 994,CC_measurement_wavelength,700,Constant
-994,CC_scale_factor_cdom,0.0734,
+994,CC_scale_factor_cdom,0.1181391225738448,New cdom scaling factor = old scaling factor (0.0734) * scaling factor (5.62) * correction factor (0.28639231863102)
 994,CC_scale_factor_chlorophyll_a,0.0116,
 994,CC_scale_factor_volume_scatter,1.872e-06,
 994,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-00994__20171013.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00994__20171013.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 994,CC_dark_counts_volume_scatter,44,
 994,CC_depolarization_ratio,0.039,Constant
 994,CC_measurement_wavelength,700,Constant
-994,CC_scale_factor_cdom,0.0724,
+994,CC_scale_factor_cdom,0.1165295977431385,New cdom scaling factor = old scaling factor (0.0724) * scaling factor (5.62) * correction factor (0.28639231863102)
 994,CC_scale_factor_chlorophyll_a,0.0113,
 994,CC_scale_factor_volume_scatter,2.317E-06,
 994,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-00994__20240109.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00994__20240109.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 994,CC_dark_counts_volume_scatter,49.675,
 994,CC_depolarization_ratio,0.039,Constant
 994,CC_measurement_wavelength,700,Constant
-994,CC_scale_factor_cdom,1.346E-01,
+994,CC_scale_factor_cdom,1.346E-01,This calibration not affected by CDOM calibration correction
 994,CC_scale_factor_chlorophyll_a,1.208E-02,
 994,CC_scale_factor_volume_scatter,2.041E-06,
 994,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01003__20121120.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01003__20121120.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1003,CC_dark_counts_volume_scatter,55,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1003,CC_depolarization_ratio,0.039,Constant
 1003,CC_measurement_wavelength,700,Constant
-1003,CC_scale_factor_cdom,0.0907,
+1003,CC_scale_factor_cdom,0.1514559879160404,New cdom scaling factor = old scaling factor (0.0907) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1003,CC_scale_factor_chlorophyll_a,0.0122,
 1003,CC_scale_factor_volume_scatter,2.109E-06,Depth
 1003,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01003__20160525.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01003__20160525.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1003,CC_dark_counts_volume_scatter,50,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1003,CC_depolarization_ratio,0.039,Constant
 1003,CC_measurement_wavelength,700,Constant
-1003,CC_scale_factor_cdom,0.0809,
+1003,CC_scale_factor_cdom,0.1302105588041423,New cdom scaling factor = old scaling factor (0.0809) * scaling factor (5.62) * correction factor (0.28639231863102)
 1003,CC_scale_factor_chlorophyll_a,0.013,
 1003,CC_scale_factor_volume_scatter,1.844e-06,Depth
 1003,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01003__20180728.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01003__20180728.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1003,CC_dark_counts_volume_scatter,50,
 1003,CC_depolarization_ratio,0.039,Constant
 1003,CC_measurement_wavelength,700,Constant
-1003,CC_scale_factor_cdom,0.0765,
+1003,CC_scale_factor_cdom,0.1231286495490344,New cdom scaling factor = old scaling factor (0.0765) * scaling factor (5.62) * correction factor (0.28639231863102)
 1003,CC_scale_factor_chlorophyll_a,0.0104,
 1003,CC_scale_factor_volume_scatter,1.931e-06,
 1003,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01003__20220218.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01003__20220218.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1003,CC_dark_counts_volume_scatter,46.175,
 1003,CC_depolarization_ratio,0.039,Constant
 1003,CC_measurement_wavelength,700,Constant
-1003,CC_scale_factor_cdom,8.887E-02,
+1003,CC_scale_factor_cdom,0.3786889986403893,New cdom scaling factor = old scaling factor (0.08887) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1003,CC_scale_factor_chlorophyll_a,1.205E-02,
 1003,CC_scale_factor_volume_scatter,1.818E-06,
 1003,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01003__20220913.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01003__20220913.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1003,CC_dark_counts_volume_scatter,46.175,
 1003,CC_depolarization_ratio,0.039,Constant
 1003,CC_measurement_wavelength,700,Constant
-1003,CC_scale_factor_cdom,8.887E-02,
+1003,CC_scale_factor_cdom,0.3786889986403893,New cdom scaling factor = old scaling factor (0.08887) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1003,CC_scale_factor_chlorophyll_a,1.205E-02,
 1003,CC_scale_factor_volume_scatter,1.835E-06,
 1003,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01004__20121120.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01004__20121120.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1004,CC_dark_counts_volume_scatter,65,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1004,CC_depolarization_ratio,0.039,"Default value per <flo_scat_seawater(degC, psu, theta=117.0, wlngth=700.0, delta=0.039)>"
 1004,CC_measurement_wavelength,700,"Default value per <flo_bback_total(beta, degC=20.0, psu=32.0, theta=117.0, wlngth=700.0, xfactor=1.08)>"
-1004,CC_scale_factor_cdom,0.0905,
+1004,CC_scale_factor_cdom,0.1511220166086181,New cdom scaling factor = old scaling factor (0.0905) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1004,CC_scale_factor_chlorophyll_a,0.0121,
 1004,CC_scale_factor_volume_scatter,2.116e-06,Depth
 1004,CC_scattering_angle,124,"Default value per <flo_bback_total(beta, degC=20.0, psu=32.0, theta=117.0, wlngth=700.0, xfactor=1.08)>"

--- a/calibration/FLORTD/CGINS-FLORTD-01004__20161004.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01004__20161004.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1004,CC_dark_counts_volume_scatter,51,
 1004,CC_depolarization_ratio,0.039,Constant
 1004,CC_measurement_wavelength,700,Constant
-1004,CC_scale_factor_cdom,0.0727,
+1004,CC_scale_factor_cdom,0.1170124551923503,New cdom scaling factor = old scaling factor (0.0727) * scaling factor (5.62) * correction factor (0.28639231863102)
 1004,CC_scale_factor_chlorophyll_a,0.0114,
 1004,CC_scale_factor_volume_scatter,1.816E-06,
 1004,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01004__20181003.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01004__20181003.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1004,CC_dark_counts_volume_scatter,54,
 1004,CC_depolarization_ratio,0.039,Constant
 1004,CC_measurement_wavelength,700,Constant
-1004,CC_scale_factor_cdom,0.0661,
+1004,CC_scale_factor_cdom,0.1063895913096886,New cdom scaling factor = old scaling factor (0.0661) * scaling factor (5.62) * correction factor (0.28639231863102)
 1004,CC_scale_factor_chlorophyll_a,0.0114,
 1004,CC_scale_factor_volume_scatter,1.985E-06,
 1004,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01004__20220927.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01004__20220927.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1004,CC_dark_counts_volume_scatter,51,
 1004,CC_depolarization_ratio,0.039,Constant
 1004,CC_measurement_wavelength,700,Constant
-1004,CC_scale_factor_cdom,8.386E-02,
+1004,CC_scale_factor_cdom,0.3573406034205362,New cdom scaling factor = old scaling factor (0.08386) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1004,CC_scale_factor_chlorophyll_a,1.084E-02,
 1004,CC_scale_factor_volume_scatter,1.726E-06,
 1004,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01005__20121120.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01005__20121120.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1005,CC_dark_counts_volume_scatter,54,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1005,CC_depolarization_ratio,0.039,"Default value per <flo_scat_seawater(degC, psu, theta=117.0, wlngth=700.0, delta=0.039)>"
 1005,CC_measurement_wavelength,700,"Default value per <flo_bback_total(beta, degC=20.0, psu=32.0, theta=117.0, wlngth=700.0, xfactor=1.08)>"
-1005,CC_scale_factor_cdom,0.0911,
+1005,CC_scale_factor_cdom,0.1521239305308852,New cdom scaling factor = old scaling factor (0.0911) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1005,CC_scale_factor_chlorophyll_a,0.0121,
 1005,CC_scale_factor_volume_scatter,2.118e-06,Depth
 1005,CC_scattering_angle,124,"Default value per <flo_bback_total(beta, degC=20.0, psu=32.0, theta=117.0, wlngth=700.0, xfactor=1.08)>"

--- a/calibration/FLORTD/CGINS-FLORTD-01005__20171229.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01005__20171229.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1005,CC_dark_counts_volume_scatter,50,
 1005,CC_depolarization_ratio,0.039,constant
 1005,CC_measurement_wavelength,700,constant
-1005,CC_scale_factor_cdom,0.0644,
+1005,CC_scale_factor_cdom,0.1036533990974878,New cdom scaling factor = old scaling factor (0.0644) * scaling factor (5.62) * correction factor (0.28639231863102)
 1005,CC_scale_factor_chlorophyll_a,0.0109,
 1005,CC_scale_factor_volume_scatter,2.197E-06,
 1005,CC_scattering_angle,124,constant

--- a/calibration/FLORTD/CGINS-FLORTD-01005__20220222.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01005__20220222.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1005,CC_dark_counts_volume_scatter,44.625,
 1005,CC_depolarization_ratio,0.039,constant
 1005,CC_measurement_wavelength,700,constant
-1005,CC_scale_factor_cdom,9.111E-02,
+1005,CC_scale_factor_cdom,0.3882339897167308,New cdom scaling factor = old scaling factor (0.09111) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1005,CC_scale_factor_chlorophyll_a,1.101E-02,
 1005,CC_scale_factor_volume_scatter,1.737E-06,
 1005,CC_scattering_angle,124,constant

--- a/calibration/FLORTD/CGINS-FLORTD-01102__20130830.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01102__20130830.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1102,CC_dark_counts_volume_scatter,52,Measured signal output of fluormeter in clean water with black tape over the detector [counts]
 1102,CC_depolarization_ratio,0.039,Depolarization ratio [unitless].
 1102,CC_measurement_wavelength,700,"Default values defined in DPA: def flo_scat_seawater(degC, psu, theta=117.0, wlngth=700.0, delta=0.039)"
-1102,CC_scale_factor_cdom,0.0905,Multiplier [ppb counts^-1]
+1102,CC_scale_factor_cdom,0.1511220166086181,New cdom scaling factor = old scaling factor (0.0905) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1102,CC_scale_factor_chlorophyll_a,0.0123,Multiplier [ug L^-1 counts^-1]
 1102,CC_scale_factor_volume_scatter,1.82e-06,Multiplier [m^-1 sr^-1 counts^-1]
 1102,CC_scattering_angle,124,"Default values defined in DPA: def flo_bback_total(beta, degC=20.0, psu=32.0, theta=117.0, wlngth=700.0, xfactor=1.08)"

--- a/calibration/FLORTD/CGINS-FLORTD-01102__20151119.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01102__20151119.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1102,CC_dark_counts_volume_scatter,47,
 1102,CC_depolarization_ratio,0.039,Constant
 1102,CC_measurement_wavelength,700,Constant
-1102,CC_scale_factor_cdom,0.0844,
+1102,CC_scale_factor_cdom,0.1358438957116144,New cdom scaling factor = old scaling factor (0.0844) * scaling factor (5.62) * correction factor (0.28639231863102)
 1102,CC_scale_factor_chlorophyll_a,0.0117,
 1102,CC_scale_factor_volume_scatter,1.803e-06,
 1102,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01102__20170105.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01102__20170105.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1102,CC_dark_counts_volume_scatter,47,
 1102,CC_depolarization_ratio,0.039,Constant
 1102,CC_measurement_wavelength,700,Constant
-1102,CC_scale_factor_cdom,0.0729,
+1102,CC_scale_factor_cdom,0.1173343601584916,New cdom scaling factor = old scaling factor (0.0729) * scaling factor (5.62) * correction factor (0.28639231863102)
 1102,CC_scale_factor_chlorophyll_a,0.0114,
 1102,CC_scale_factor_volume_scatter,2.142E-06,
 1102,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01102__20180730.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01102__20180730.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1102,CC_dark_counts_volume_scatter,46,
 1102,CC_depolarization_ratio,0.039,Constant
 1102,CC_measurement_wavelength,700,Constant
-1102,CC_scale_factor_cdom,0.0814,
+1102,CC_scale_factor_cdom,0.1310153212194954,New cdom scaling factor = old scaling factor (0.0814) * scaling factor (5.62) * correction factor (0.28639231863102)
 1102,CC_scale_factor_chlorophyll_a,0.0116,
 1102,CC_scale_factor_volume_scatter,2.665E-06,
 1102,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01102__20201110.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01102__20201110.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1102,CC_dark_counts_volume_scatter,40,
 1102,CC_depolarization_ratio,0.039,Constant
 1102,CC_measurement_wavelength,700,Constant
-1102,CC_scale_factor_cdom,0.0657,
+1102,CC_scale_factor_cdom,0.2799579971944815,New cdom scaling factor = old scaling factor (0.0657) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1102,CC_scale_factor_chlorophyll_a,0.0106,
 1102,CC_scale_factor_volume_scatter,2.016E-06,
 1102,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01102__20220105.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01102__20220105.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1102,CC_dark_counts_volume_scatter,75,
 1102,CC_depolarization_ratio,0.039,Constant
 1102,CC_measurement_wavelength,700,Constant
-1102,CC_scale_factor_cdom,9.070E-02,
+1102,CC_scale_factor_cdom,0.3864869154572219,New cdom scaling factor = old scaling factor (0.0907) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1102,CC_scale_factor_chlorophyll_a,1.180E-02,
 1102,CC_scale_factor_volume_scatter,2.242E-06,
 1102,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01102__20240923.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01102__20240923.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1102,CC_dark_counts_volume_scatter,40,
 1102,CC_depolarization_ratio,0.039,Constant
 1102,CC_measurement_wavelength,700,Constant
-1102,CC_scale_factor_cdom,9.144E-02,
+1102,CC_scale_factor_cdom,9.144E-02,This calibration not affected by CDOM calibration correction
 1102,CC_scale_factor_chlorophyll_a,1.208E-02,
 1102,CC_scale_factor_volume_scatter,1.783E-06,
 1102,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01104__20130909.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01104__20130909.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1104,CC_dark_counts_volume_scatter,51,Measured signal output of fluormeter in clean water with black tape over the detector [counts]
 1104,CC_depolarization_ratio,0.039,Depolarization ratio [unitless].
 1104,CC_measurement_wavelength,700,"Default values defined in DPA: def flo_scat_seawater(degC, psu, theta=117.0, wlngth=700.0, delta=0.039)"
-1104,CC_scale_factor_cdom,0.0904,Multiplier [ppb counts^-1]
+1104,CC_scale_factor_cdom,0.1509550309549069,New cdom scaling factor = old scaling factor (0.0904) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1104,CC_scale_factor_chlorophyll_a,0.0121,Multiplier [ug L^-1 counts^-1]
 1104,CC_scale_factor_volume_scatter,1.675e-06,Multiplier [m^-1 sr^-1 counts^-1]
 1104,CC_scattering_angle,124,"Default values defined in DPA: def flo_bback_total(beta, degC=20.0, psu=32.0, theta=117.0, wlngth=700.0, xfactor=1.08)"

--- a/calibration/FLORTD/CGINS-FLORTD-01105__20130909.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01105__20130909.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1105,CC_dark_counts_volume_scatter,59,
 1105,CC_depolarization_ratio,0.039,Constant
 1105,CC_measurement_wavelength,700,Constant
-1105,CC_scale_factor_cdom,0.0901,
+1105,CC_scale_factor_cdom,0.1504540739937734,New cdom scaling factor = old scaling factor (0.0901) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1105,CC_scale_factor_chlorophyll_a,0.0122,
 1105,CC_scale_factor_volume_scatter,1.684e-06,
 1105,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01105__20160512.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01105__20160512.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1105,CC_dark_counts_volume_scatter,50,
 1105,CC_depolarization_ratio,0.039,Constant
 1105,CC_measurement_wavelength,700,Constant
-1105,CC_scale_factor_cdom,0.0849,
+1105,CC_scale_factor_cdom,0.1366486581269676,New cdom scaling factor = old scaling factor (0.0849) * scaling factor (5.62) * correction factor (0.28639231863102)
 1105,CC_scale_factor_chlorophyll_a,0.0118,
 1105,CC_scale_factor_volume_scatter,1.738E-06,
 1105,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01105__20180329.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01105__20180329.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1105,CC_dark_counts_volume_scatter,51,
 1105,CC_depolarization_ratio,0.039,Constant
 1105,CC_measurement_wavelength,700,Constant
-1105,CC_scale_factor_cdom,0.0732,
+1105,CC_scale_factor_cdom,0.1178172176077035,New cdom scaling factor = old scaling factor (0.0732) * scaling factor (5.62) * correction factor (0.28639231863102)
 1105,CC_scale_factor_chlorophyll_a,0.0119,
 1105,CC_scale_factor_volume_scatter,2.141E-06,
 1105,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01105__20201105.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01105__20201105.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1105,CC_dark_counts_volume_scatter,47,
 1105,CC_depolarization_ratio,0.039,Constant
 1105,CC_measurement_wavelength,700,Constant
-1105,CC_scale_factor_cdom,0.0764,
+1105,CC_scale_factor_cdom,0.3255523742109344,New cdom scaling factor = old scaling factor (0.0764) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1105,CC_scale_factor_chlorophyll_a,0.0114,
 1105,CC_scale_factor_volume_scatter,2.377E-06,
 1105,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01106__20130913.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01106__20130913.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1106,CC_dark_counts_volume_scatter,51,
 1106,CC_depolarization_ratio,0.039,Constant
 1106,CC_measurement_wavelength,700,Constant
-1106,CC_scale_factor_cdom,0.0904,
+1106,CC_scale_factor_cdom,0.1509550309549069,New cdom scaling factor = old scaling factor (0.0904) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1106,CC_scale_factor_chlorophyll_a,0.0121,
 1106,CC_scale_factor_volume_scatter,1.696e-06,
 1106,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01106__20160112.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01106__20160112.csv
@@ -6,7 +6,7 @@ serial,name,value,notes
 Use CTD data from GI01SUMO-RID16-03-CTDBPF000."
 1106,CC_depolarization_ratio,0.039,Constant
 1106,CC_measurement_wavelength,700,Constant
-1106,CC_scale_factor_cdom,0.0739,
+1106,CC_scale_factor_cdom,0.1189438849891979,New cdom scaling factor = old scaling factor (0.0739) * scaling factor (5.62) * correction factor (0.28639231863102)
 1106,CC_scale_factor_chlorophyll_a,0.0116,
 1106,CC_scale_factor_volume_scatter,1.745E-06,
 1106,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01106__20171013.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01106__20171013.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1106,CC_dark_counts_volume_scatter,43,
 1106,CC_depolarization_ratio,0.039,Constant
 1106,CC_measurement_wavelength,700,Constant
-1106,CC_scale_factor_cdom,0.0641,
+1106,CC_scale_factor_cdom,0.1031705416482759,New cdom scaling factor = old scaling factor (0.0641) * scaling factor (5.62) * correction factor (0.28639231863102)
 1106,CC_scale_factor_chlorophyll_a,0.0114,
 1106,CC_scale_factor_volume_scatter,2.156E-06,
 1106,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01106__20220224.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01106__20220224.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1106,CC_dark_counts_volume_scatter,46.675,
 1106,CC_depolarization_ratio,0.039,Constant
 1106,CC_measurement_wavelength,700,Constant
-1106,CC_scale_factor_cdom,8.436E-02,
+1106,CC_scale_factor_cdom,0.359471181785791,New cdom scaling factor = old scaling factor (0.08436) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1106,CC_scale_factor_chlorophyll_a,1.163E-02,
 1106,CC_scale_factor_volume_scatter,1.740E-06,
 1106,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01107__20130909.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01107__20130909.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1107,CC_dark_counts_volume_scatter,52,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1107,CC_depolarization_ratio,0.039,Constant
 1107,CC_measurement_wavelength,700,Constant
-1107,CC_scale_factor_cdom,0.0903,
+1107,CC_scale_factor_cdom,0.1507880453011957,New cdom scaling factor = old scaling factor (0.0903) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1107,CC_scale_factor_chlorophyll_a,0.0122,
 1107,CC_scale_factor_volume_scatter,1.695e-06,Depth
 1107,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01107__20160204.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01107__20160204.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1107,CC_dark_counts_volume_scatter,48,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1107,CC_depolarization_ratio,0.039,Constant
 1107,CC_measurement_wavelength,700,Constant
-1107,CC_scale_factor_cdom,0.0775,
+1107,CC_scale_factor_cdom,0.1247381743797407,New cdom scaling factor = old scaling factor (0.0775) * scaling factor (5.62) * correction factor (0.28639231863102)
 1107,CC_scale_factor_chlorophyll_a,0.0113,
 1107,CC_scale_factor_volume_scatter,1.654e-06,Depth
 1107,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01107__20171011.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01107__20171011.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1107,CC_dark_counts_volume_scatter,48,
 1107,CC_depolarization_ratio,0.039,Constant
 1107,CC_measurement_wavelength,700,Constant
-1107,CC_scale_factor_cdom,0.0723,
+1107,CC_scale_factor_cdom,0.1163686452600678,New cdom scaling factor = old scaling factor (0.0723) * scaling factor (5.62) * correction factor (0.28639231863102)
 1107,CC_scale_factor_chlorophyll_a,0.0118,
 1107,CC_scale_factor_volume_scatter,1.916E-06,
 1107,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01107__20201113.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01107__20201113.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1107,CC_dark_counts_volume_scatter,47,
 1107,CC_depolarization_ratio,0.039,Constant
 1107,CC_measurement_wavelength,700,Constant
-1107,CC_scale_factor_cdom,0.0779,
+1107,CC_scale_factor_cdom,0.3319441093066988,New cdom scaling factor = old scaling factor (0.0779) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1107,CC_scale_factor_chlorophyll_a,0.0121,
 1107,CC_scale_factor_volume_scatter,2.377E-06,
 1107,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01107__20240731.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01107__20240731.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1107,CC_dark_counts_volume_scatter,45.625,
 1107,CC_depolarization_ratio,0.039,Constant
 1107,CC_measurement_wavelength,700,Constant
-1107,CC_scale_factor_cdom,8.967E-02,
+1107,CC_scale_factor_cdom,8.967E-02,This calibration not affected by CDOM calibration correction
 1107,CC_scale_factor_chlorophyll_a,1.213E-02,
 1107,CC_scale_factor_volume_scatter,1.803E-06,
 1107,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01116__20130925.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01116__20130925.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1116,CC_dark_counts_volume_scatter,52,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1116,CC_depolarization_ratio,0.039,"Default value per <flo_scat_seawater(degC, psu, theta=117.0, wlngth=700.0, delta=0.039)>"
 1116,CC_measurement_wavelength,700,"Default value per <flo_bback_total(beta, degC=20.0, psu=32.0, theta=117.0, wlngth=700.0, xfactor=1.08)>"
-1116,CC_scale_factor_cdom,0.0903,
+1116,CC_scale_factor_cdom,0.1507880453011957,New cdom scaling factor = old scaling factor (0.0903) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1116,CC_scale_factor_chlorophyll_a,0.0121,
 1116,CC_scale_factor_volume_scatter,1.777e-06,Depth
 1116,CC_scattering_angle,124,"Default value per <flo_bback_total(beta, degC=20.0, psu=32.0, theta=117.0, wlngth=700.0, xfactor=1.08)>"

--- a/calibration/FLORTD/CGINS-FLORTD-01116__20151207.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01116__20151207.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1116,CC_dark_counts_volume_scatter,49,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1116,CC_depolarization_ratio,0.039,Constant
 1116,CC_measurement_wavelength,700,Constant
-1116,CC_scale_factor_cdom,0.0902,
+1116,CC_scale_factor_cdom,0.1451791397297112,New cdom scaling factor = old scaling factor (0.0902) * scaling factor (5.62) * correction factor (0.28639231863102)
 1116,CC_scale_factor_chlorophyll_a,0.0118,
 1116,CC_scale_factor_volume_scatter,1.816e-06,Depth
 1116,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01116__20171011.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01116__20171011.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1116,CC_dark_counts_volume_scatter,46,
 1116,CC_depolarization_ratio,0.039,Constant
 1116,CC_measurement_wavelength,700,Constant
-1116,CC_scale_factor_cdom,0.0746,
+1116,CC_scale_factor_cdom,0.1200705523706924,New cdom scaling factor = old scaling factor (0.0746) * scaling factor (5.62) * correction factor (0.28639231863102)
 1116,CC_scale_factor_chlorophyll_a,0.0115,
 1116,CC_scale_factor_volume_scatter,2.073E-06,
 1116,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01116__20201110.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01116__20201110.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1116,CC_dark_counts_volume_scatter,46,
 1116,CC_depolarization_ratio,0.039,Constant
 1116,CC_measurement_wavelength,700,Constant
-1116,CC_scale_factor_cdom,0.0642,
+1116,CC_scale_factor_cdom,0.2735662620987171,New cdom scaling factor = old scaling factor (0.0642) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1116,CC_scale_factor_chlorophyll_a,0.0112,
 1116,CC_scale_factor_volume_scatter,2.190E-06,
 1116,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01116__20220923.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01116__20220923.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1116,CC_dark_counts_volume_scatter,49,
 1116,CC_depolarization_ratio,0.039,Constant
 1116,CC_measurement_wavelength,700,Constant
-1116,CC_scale_factor_cdom,7.899E-02,
+1116,CC_scale_factor_cdom,0.3365887701429543,New cdom scaling factor = old scaling factor (0.07899) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1116,CC_scale_factor_chlorophyll_a,1.183E-02,
 1116,CC_scale_factor_volume_scatter,2.014E-06,
 1116,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01122__20130925.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01122__20130925.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1122,CC_dark_counts_volume_scatter,52,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1122,CC_depolarization_ratio,0.039,Constant
 1122,CC_measurement_wavelength,700,Constant
-1122,CC_scale_factor_cdom,0.0903,
+1122,CC_scale_factor_cdom,0.1507880453011957,New cdom scaling factor = old scaling factor (0.0903) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1122,CC_scale_factor_chlorophyll_a,0.0117,
 1122,CC_scale_factor_volume_scatter,1.819e-06,Depth
 1122,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01122__20160204.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01122__20160204.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1122,CC_dark_counts_volume_scatter,50,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1122,CC_depolarization_ratio,0.039,Constant
 1122,CC_measurement_wavelength,700,Constant
-1122,CC_scale_factor_cdom,0.0733,
+1122,CC_scale_factor_cdom,0.1179781700907742,New cdom scaling factor = old scaling factor (0.0733) * scaling factor (5.62) * correction factor (0.28639231863102)
 1122,CC_scale_factor_chlorophyll_a,0.0107,
 1122,CC_scale_factor_volume_scatter,1.623e-06,Depth
 1122,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01122__20180627.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01122__20180627.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1122,CC_dark_counts_volume_scatter,51,
 1122,CC_depolarization_ratio,0.039,Constant
 1122,CC_measurement_wavelength,700,Constant
-1122,CC_scale_factor_cdom,0.0652,
+1122,CC_scale_factor_cdom,0.1049410189620528,New cdom scaling factor = old scaling factor (0.0652) * scaling factor (5.62) * correction factor (0.28639231863102)
 1122,CC_scale_factor_chlorophyll_a,0.0106,
 1122,CC_scale_factor_volume_scatter,1.743e-06,
 1122,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01122__20240111.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01122__20240111.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1122,CC_dark_counts_volume_scatter,50.075,
 1122,CC_depolarization_ratio,0.039,Constant
 1122,CC_measurement_wavelength,700,Constant
-1122,CC_scale_factor_cdom,8.995E-02,
+1122,CC_scale_factor_cdom,8.995E-02,This calibration not affected by CDOM calibration correction
 1122,CC_scale_factor_chlorophyll_a,1.209E-02,
 1122,CC_scale_factor_volume_scatter,1.761E-06,
 1122,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01124__20130927.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01124__20130927.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1124,CC_dark_counts_volume_scatter,50,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1124,CC_depolarization_ratio,0.039,"Default value per <flo_scat_seawater(degC, psu, theta=117.0, wlngth=700.0, delta=0.039)>"
 1124,CC_measurement_wavelength,700,"Default value per <flo_bback_total(beta, degC=20.0, psu=32.0, theta=117.0, wlngth=700.0, xfactor=1.08)>"
-1124,CC_scale_factor_cdom,0.0902,
+1124,CC_scale_factor_cdom,0.1506210596474846,New cdom scaling factor = old scaling factor (0.0902) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1124,CC_scale_factor_chlorophyll_a,0.012,
 1124,CC_scale_factor_volume_scatter,1.71e-06,Depth
 1124,CC_scattering_angle,124,"Default value per <flo_bback_total(beta, degC=20.0, psu=32.0, theta=117.0, wlngth=700.0, xfactor=1.08)>"

--- a/calibration/FLORTD/CGINS-FLORTD-01124__20151218.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01124__20151218.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1124,CC_dark_counts_volume_scatter,50,
 1124,CC_depolarization_ratio,0.039,constant
 1124,CC_measurement_wavelength,700,constant
-1124,CC_scale_factor_cdom,0.0896,
+1124,CC_scale_factor_cdom,0.1442134248312874,New cdom scaling factor = old scaling factor (0.0896) * scaling factor (5.62) * correction factor (0.28639231863102)
 1124,CC_scale_factor_chlorophyll_a,0.0117,
 1124,CC_scale_factor_volume_scatter,1.672E-06,
 1124,CC_scattering_angle,124,constant

--- a/calibration/FLORTD/CGINS-FLORTD-01124__20181003.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01124__20181003.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1124,CC_dark_counts_volume_scatter,50,
 1124,CC_depolarization_ratio,0.039,constant
 1124,CC_measurement_wavelength,700,constant
-1124,CC_scale_factor_cdom,0.0799,
+1124,CC_scale_factor_cdom,0.1286010339734359,New cdom scaling factor = old scaling factor (0.0799) * scaling factor (5.62) * correction factor (0.28639231863102)
 1124,CC_scale_factor_chlorophyll_a,0.0118,
 1124,CC_scale_factor_volume_scatter,1.853E-06,
 1124,CC_scattering_angle,124,constant

--- a/calibration/FLORTD/CGINS-FLORTD-01124__20220927.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01124__20220927.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1124,CC_dark_counts_volume_scatter,50,
 1124,CC_depolarization_ratio,0.039,Constant
 1124,CC_measurement_wavelength,700,Constant
-1124,CC_scale_factor_cdom,9.147E-02,
+1124,CC_scale_factor_cdom,0.3897680061397143,New cdom scaling factor = old scaling factor (0.09147) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1124,CC_scale_factor_chlorophyll_a,1.154E-02,
 1124,CC_scale_factor_volume_scatter,1.586E-06,
 1124,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01212__20140819.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01212__20140819.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1212,CC_dark_counts_volume_scatter,43,
 1212,CC_depolarization_ratio,0.039,Constant
 1212,CC_measurement_wavelength,700,Constant
-1212,CC_scale_factor_cdom,0.0903,
+1212,CC_scale_factor_cdom,0.1125070778703469,New cdom scaling factor = old scaling factor (0.0903) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1212,CC_scale_factor_chlorophyll_a,0.0122,
 1212,CC_scale_factor_volume_scatter,1.883e-06,
 1212,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01212__20160518.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01212__20160518.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1212,CC_dark_counts_volume_scatter,42,
 1212,CC_depolarization_ratio,0.039,Constant
 1212,CC_measurement_wavelength,700,Constant
-1212,CC_scale_factor_cdom,0.0873,
+1212,CC_scale_factor_cdom,0.1405115177206628,New cdom scaling factor = old scaling factor (0.0873) * scaling factor (5.62) * correction factor (0.28639231863102)
 1212,CC_scale_factor_chlorophyll_a,0.0116,
 1212,CC_scale_factor_volume_scatter,2.057E-06,
 1212,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01212__20180329.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01212__20180329.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1212,CC_dark_counts_volume_scatter,49,
 1212,CC_depolarization_ratio,0.039,Constant
 1212,CC_measurement_wavelength,700,Constant
-1212,CC_scale_factor_cdom,0.0703,
+1212,CC_scale_factor_cdom,0.1131495955986551,New cdom scaling factor = old scaling factor (0.0703) * scaling factor (5.62) * correction factor (0.28639231863102)
 1212,CC_scale_factor_chlorophyll_a,0.0120,
 1212,CC_scale_factor_volume_scatter,2.309E-06,
 1212,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01212__20211223.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01212__20211223.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1212,CC_dark_counts_volume_scatter,49,
 1212,CC_depolarization_ratio,0.039,Constant
 1212,CC_measurement_wavelength,700,Constant
-1212,CC_scale_factor_cdom,9.060E-02,
+1212,CC_scale_factor_cdom,0.3860607997841709,New cdom scaling factor = old scaling factor (0.0906) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1212,CC_scale_factor_chlorophyll_a,1.160E-02,
 1212,CC_scale_factor_volume_scatter,2.210E-06,
 1212,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01212__20240730.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01212__20240730.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1212,CC_dark_counts_volume_scatter,47,
 1212,CC_depolarization_ratio,0.039,Constant
 1212,CC_measurement_wavelength,700,Constant
-1212,CC_scale_factor_cdom,9.021E-02,
+1212,CC_scale_factor_cdom,9.021E-02,This calibration not affected by CDOM calibration correction
 1212,CC_scale_factor_chlorophyll_a,1.209E-02,
 1212,CC_scale_factor_volume_scatter,1.832E-06,
 1212,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01213__20140625.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01213__20140625.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1213,CC_dark_counts_volume_scatter,50,
 1213,CC_depolarization_ratio,0.039,Constant
 1213,CC_measurement_wavelength,700,Constant
-1213,CC_scale_factor_cdom,0.0908,
+1213,CC_scale_factor_cdom,0.1131300406492525,New cdom scaling factor = old scaling factor (0.0908) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1213,CC_scale_factor_chlorophyll_a,0.0121,
 1213,CC_scale_factor_volume_scatter,1.83e-06,
 1213,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01213__20170105.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01213__20170105.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1213,CC_dark_counts_volume_scatter,49,
 1213,CC_depolarization_ratio,0.039,Constant
 1213,CC_measurement_wavelength,700,Constant
-1213,CC_scale_factor_cdom,0.0787,
+1213,CC_scale_factor_cdom,0.1266696041765883,New cdom scaling factor = old scaling factor (0.0787) * scaling factor (5.62) * correction factor (0.28639231863102)
 1213,CC_scale_factor_chlorophyll_a,0.0119,
 1213,CC_scale_factor_volume_scatter,2.04E-06,
 1213,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01213__20180731.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01213__20180731.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1213,CC_dark_counts_volume_scatter,50,
 1213,CC_depolarization_ratio,0.039,Constant
 1213,CC_measurement_wavelength,700,Constant
-1213,CC_scale_factor_cdom,0.0739,
+1213,CC_scale_factor_cdom,0.1189438849891979,New cdom scaling factor = old scaling factor (0.0739) * scaling factor (5.62) * correction factor (0.28639231863102)
 1213,CC_scale_factor_chlorophyll_a,0.0120,
 1213,CC_scale_factor_volume_scatter,2.478E-06,
 1213,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01213__20201112.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01213__20201112.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1213,CC_dark_counts_volume_scatter,47,
 1213,CC_depolarization_ratio,0.039,Constant
 1213,CC_measurement_wavelength,700,Constant
-1213,CC_scale_factor_cdom,0.0909,
+1213,CC_scale_factor_cdom,0.3873391468033239,New cdom scaling factor = old scaling factor (0.0909) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1213,CC_scale_factor_chlorophyll_a,0.0118,
 1213,CC_scale_factor_volume_scatter,2.013E-06,
 1213,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01213__20231128.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01213__20231128.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1213,CC_dark_counts_volume_scatter,53.175,
 1213,CC_depolarization_ratio,0.039,Constant
 1213,CC_measurement_wavelength,700,Constant
-1213,CC_scale_factor_cdom,9.067E-02,
+1213,CC_scale_factor_cdom,9.067E-02,This calibration not affected by CDOM calibration correction
 1213,CC_scale_factor_chlorophyll_a,1.207E-02,
 1213,CC_scale_factor_volume_scatter,1.726E-06,
 1213,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01214__20140625.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01214__20140625.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1214,CC_dark_counts_volume_scatter,51,
 1214,CC_depolarization_ratio,0.039,Constant
 1214,CC_measurement_wavelength,700,Constant
-1214,CC_scale_factor_cdom,0.0908,
+1214,CC_scale_factor_cdom,0.1131300406492525,New cdom scaling factor = old scaling factor (0.0908) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1214,CC_scale_factor_chlorophyll_a,0.0121,
 1214,CC_scale_factor_volume_scatter,1.851e-06,
 1214,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01214__20160622.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01214__20160622.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1214,CC_dark_counts_volume_scatter,51,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1214,CC_depolarization_ratio,0.039,Constant
 1214,CC_measurement_wavelength,700,Constant
-1214,CC_scale_factor_cdom,0.0924,
+1214,CC_scale_factor_cdom,0.1487200943572651,New cdom scaling factor = old scaling factor (0.0924) * scaling factor (5.62) * correction factor (0.28639231863102)
 1214,CC_scale_factor_chlorophyll_a,0.0122,
 1214,CC_scale_factor_volume_scatter,2.109e-06,Depth
 1214,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01214__20180801.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01214__20180801.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1214,CC_dark_counts_volume_scatter,50,
 1214,CC_depolarization_ratio,0.039,Constant
 1214,CC_measurement_wavelength,700,Constant
-1214,CC_scale_factor_cdom,0.0843,
+1214,CC_scale_factor_cdom,0.1356829432285438,New cdom scaling factor = old scaling factor (0.0843) * scaling factor (5.62) * correction factor (0.28639231863102)
 1214,CC_scale_factor_chlorophyll_a,0.0122,
 1214,CC_scale_factor_volume_scatter,2.268e-06,
 1214,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01214__20200129.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01214__20200129.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1214,CC_dark_counts_volume_scatter,48,
 1214,CC_depolarization_ratio,0.039,Constant
 1214,CC_measurement_wavelength,700,Constant
-1214,CC_scale_factor_cdom,0.0682,
+1214,CC_scale_factor_cdom,0.1708502961648081,New cdom scaling factor = old scaling factor (0.0682) * scaling factor (5.62) * correction factor (0.4457537913526475)
 1214,CC_scale_factor_chlorophyll_a,0.0115,
 1214,CC_scale_factor_volume_scatter,2.166e-06,
 1214,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01214__20210706.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01214__20210706.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1214,CC_dark_counts_volume_scatter,50,
 1214,CC_depolarization_ratio,0.039,Constant
 1214,CC_measurement_wavelength,700,Constant
-1214,CC_scale_factor_cdom,0.0621,
+1214,CC_scale_factor_cdom,0.2646178329646469,New cdom scaling factor = old scaling factor (0.0621) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1214,CC_scale_factor_chlorophyll_a,0.0121,
 1214,CC_scale_factor_volume_scatter,2.350e-06,
 1214,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01214__20231030.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01214__20231030.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1214,CC_dark_counts_volume_scatter,50,
 1214,CC_depolarization_ratio,0.039,Constant
 1214,CC_measurement_wavelength,700,Constant
-1214,CC_scale_factor_cdom,9.077E-02,
+1214,CC_scale_factor_cdom,9.077E-02,This calibration not affected by CDOM calibration correction
 1214,CC_scale_factor_chlorophyll_a,1.210E-02,
 1214,CC_scale_factor_volume_scatter,1.982E-06,
 1214,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01215__20140812.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01215__20140812.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1215,CC_dark_counts_volume_scatter,51,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1215,CC_depolarization_ratio,0.039,Constant
 1215,CC_measurement_wavelength,700,Constant
-1215,CC_scale_factor_cdom,0.0906,
+1215,CC_scale_factor_cdom,0.1128808555376902,New cdom scaling factor = old scaling factor (0.0906) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1215,CC_scale_factor_chlorophyll_a,0.0121,
 1215,CC_scale_factor_volume_scatter,1.87e-06,Depth
 1215,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01215__20160512.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01215__20160512.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1215,CC_dark_counts_volume_scatter,49,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1215,CC_depolarization_ratio,0.039,Constant
 1215,CC_measurement_wavelength,700,Constant
-1215,CC_scale_factor_cdom,0.0784,
+1215,CC_scale_factor_cdom,0.1261867467273764,New cdom scaling factor = old scaling factor (0.0784) * scaling factor (5.62) * correction factor (0.28639231863102)
 1215,CC_scale_factor_chlorophyll_a,0.0113,
 1215,CC_scale_factor_volume_scatter,1.887e-06,Depth
 1215,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01215__20180830.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01215__20180830.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1215,CC_dark_counts_volume_scatter,52,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1215,CC_depolarization_ratio,0.039,Constant
 1215,CC_measurement_wavelength,700,Constant
-1215,CC_scale_factor_cdom,0.0703,
+1215,CC_scale_factor_cdom,0.1131495955986551,New cdom scaling factor = old scaling factor (0.0703) * scaling factor (5.62) * correction factor (0.28639231863102)
 1215,CC_scale_factor_chlorophyll_a,0.0099,
 1215,CC_scale_factor_volume_scatter,1.955e-06,Depth
 1215,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01215__20210706.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01215__20210706.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1215,CC_dark_counts_volume_scatter,50,
 1215,CC_depolarization_ratio,0.039,Constant
 1215,CC_measurement_wavelength,700,Constant
-1215,CC_scale_factor_cdom,0.0552,
+1215,CC_scale_factor_cdom,0.2352158515241306,New cdom scaling factor = old scaling factor (0.0552) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1215,CC_scale_factor_chlorophyll_a,0.0104,
 1215,CC_scale_factor_volume_scatter,2.217e-06,
 1215,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01215__20231106.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01215__20231106.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1215,CC_dark_counts_volume_scatter,46,
 1215,CC_depolarization_ratio,0.039,Constant
 1215,CC_measurement_wavelength,700,Constant
-1215,CC_scale_factor_cdom,8.983E-02,
+1215,CC_scale_factor_cdom,8.983E-02,This calibration not affected by CDOM calibration correction
 1215,CC_scale_factor_chlorophyll_a,1.207E-02,
 1215,CC_scale_factor_volume_scatter,1.874E-06,
 1215,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01216__20140812.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01216__20140812.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1216,CC_dark_counts_volume_scatter,48,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1216,CC_depolarization_ratio,0.039,Constant
 1216,CC_measurement_wavelength,700,Constant
-1216,CC_scale_factor_cdom,0.0905,
+1216,CC_scale_factor_cdom,0.1127562629819091,New cdom scaling factor = old scaling factor (0.0905) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1216,CC_scale_factor_chlorophyll_a,0.0121,
 1216,CC_scale_factor_volume_scatter,1.929e-06,Depth
 1216,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01216__20160929.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01216__20160929.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1216,CC_dark_counts_volume_scatter,49,
 1216,CC_depolarization_ratio,0.039,Constant
 1216,CC_measurement_wavelength,700,Constant
-1216,CC_scale_factor_cdom,0.0796,
+1216,CC_scale_factor_cdom,0.128118176524224,New cdom scaling factor = old scaling factor (0.0796) * scaling factor (5.62) * correction factor (0.28639231863102)
 1216,CC_scale_factor_chlorophyll_a,0.0114,
 1216,CC_scale_factor_volume_scatter,1.864E-06,
 1216,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01216__20171229.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01216__20171229.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1216,CC_dark_counts_volume_scatter,51,
 1216,CC_depolarization_ratio,0.039,Constant
 1216,CC_measurement_wavelength,700,Constant
-1216,CC_scale_factor_cdom,0.0670,
+1216,CC_scale_factor_cdom,0.1078381636573243,New cdom scaling factor = old scaling factor (0.067) * scaling factor (5.62) * correction factor (0.28639231863102)
 1216,CC_scale_factor_chlorophyll_a,0.0116,
 1216,CC_scale_factor_volume_scatter,2.154E-06,
 1216,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01216__20200116.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01216__20200116.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1216,CC_dark_counts_volume_scatter,51,
 1216,CC_depolarization_ratio,0.039,Constant
 1216,CC_measurement_wavelength,700,Constant
-1216,CC_scale_factor_cdom,0.0668,
+1216,CC_scale_factor_cdom,0.1673431053344455,New cdom scaling factor = old scaling factor (0.0668) * scaling factor (5.62) * correction factor (0.4457537913526475)
 1216,CC_scale_factor_chlorophyll_a,0.0113,
 1216,CC_scale_factor_volume_scatter,2.229E-06,
 1216,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01216__20210708.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01216__20210708.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1216,CC_dark_counts_volume_scatter,46,
 1216,CC_depolarization_ratio,0.039,Constant
 1216,CC_measurement_wavelength,700,Constant
-1216,CC_scale_factor_cdom,0.0894,
+1216,CC_scale_factor_cdom,0.3809474117075594,New cdom scaling factor = old scaling factor (0.0894) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1216,CC_scale_factor_chlorophyll_a,0.0123,
 1216,CC_scale_factor_volume_scatter,2.211e-06,
 1216,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01216__20231113.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01216__20231113.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1216,CC_dark_counts_volume_scatter,53.275,
 1216,CC_depolarization_ratio,0.039,Constant
 1216,CC_measurement_wavelength,700,Constant
-1216,CC_scale_factor_cdom,9.083E-02,
+1216,CC_scale_factor_cdom,9.083E-02,This calibration not affected by CDOM calibration correction
 1216,CC_scale_factor_chlorophyll_a,1.259E-02,
 1216,CC_scale_factor_volume_scatter,1.755E-06,
 1216,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01217__20140812.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01217__20140812.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1217,CC_dark_counts_volume_scatter,45,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1217,CC_depolarization_ratio,0.039,Constant
 1217,CC_measurement_wavelength,700,Constant
-1217,CC_scale_factor_cdom,0.0909,
+1217,CC_scale_factor_cdom,0.1132546332050336,New cdom scaling factor = old scaling factor (0.0909) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1217,CC_scale_factor_chlorophyll_a,0.0121,
 1217,CC_scale_factor_volume_scatter,1.842E-06,Depth
 1217,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01217__20160525.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01217__20160525.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1217,CC_dark_counts_volume_scatter,40,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1217,CC_depolarization_ratio,0.039,Constant
 1217,CC_measurement_wavelength,700,Constant
-1217,CC_scale_factor_cdom,0.0778,
+1217,CC_scale_factor_cdom,0.1252210318289526,New cdom scaling factor = old scaling factor (0.0778) * scaling factor (5.62) * correction factor (0.28639231863102)
 1217,CC_scale_factor_chlorophyll_a,0.0124,
 1217,CC_scale_factor_volume_scatter,1.812E-06,Depth
 1217,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01217__20200117.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01217__20200117.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1217,CC_dark_counts_volume_scatter,42,
 1217,CC_depolarization_ratio,0.039,Constant
 1217,CC_measurement_wavelength,700,Constant
-1217,CC_scale_factor_cdom,0.0619,
+1217,CC_scale_factor_cdom,0.1550679374281763,New cdom scaling factor = old scaling factor (0.0619) * scaling factor (5.62) * correction factor (0.4457537913526475)
 1217,CC_scale_factor_chlorophyll_a,0.0109,
 1217,CC_scale_factor_volume_scatter,2.335E-06,
 1217,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01217__20220926.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01217__20220926.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1217,CC_dark_counts_volume_scatter,47,
 1217,CC_depolarization_ratio,0.039,Constant
 1217,CC_measurement_wavelength,700,Constant
-1217,CC_scale_factor_cdom,8.812E-02,
+1217,CC_scale_factor_cdom,0.3754931310925071,New cdom scaling factor = old scaling factor (0.08812) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1217,CC_scale_factor_chlorophyll_a,1.155E-02,
 1217,CC_scale_factor_volume_scatter,1.826E-06,
 1217,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01218__20140812.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01218__20140812.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1218,CC_dark_counts_volume_scatter,50,
 1218,CC_depolarization_ratio,0.039,Constant
 1218,CC_measurement_wavelength,700,Constant
-1218,CC_scale_factor_cdom,0.0908,
+1218,CC_scale_factor_cdom,0.1131300406492525,New cdom scaling factor = old scaling factor (0.0908) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1218,CC_scale_factor_chlorophyll_a,0.0121,
 1218,CC_scale_factor_volume_scatter,1.892e-06,
 1218,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01218__20160518.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01218__20160518.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1218,CC_dark_counts_volume_scatter,48,
 1218,CC_depolarization_ratio,0.039,Constant
 1218,CC_measurement_wavelength,700,Constant
-1218,CC_scale_factor_cdom,0.0931,
+1218,CC_scale_factor_cdom,0.1498467617387596,New cdom scaling factor = old scaling factor (0.0931) * scaling factor (5.62) * correction factor (0.28639231863102)
 1218,CC_scale_factor_chlorophyll_a,0.0121,
 1218,CC_scale_factor_volume_scatter,1.994e-06,
 1218,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01218__20200117.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01218__20200117.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1218,CC_dark_counts_volume_scatter,51,
 1218,CC_depolarization_ratio,0.039,Constant
 1218,CC_measurement_wavelength,700,Constant
-1218,CC_scale_factor_cdom,0.0991,
+1218,CC_scale_factor_cdom,0.2482590080635261,New cdom scaling factor = old scaling factor (0.0991) * scaling factor (5.62) * correction factor (0.4457537913526475)
 1218,CC_scale_factor_chlorophyll_a,0.0112,
 1218,CC_scale_factor_volume_scatter,2.573e-06,
 1218,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01218__20220113.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01218__20220113.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1218,CC_dark_counts_volume_scatter,56,
 1218,CC_depolarization_ratio,0.039,Constant
 1218,CC_measurement_wavelength,700,Constant
-1218,CC_scale_factor_cdom,0.0727,
+1218,CC_scale_factor_cdom,0.3097860943080489,New cdom scaling factor = old scaling factor (0.0727) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1218,CC_scale_factor_chlorophyll_a,0.0110,
 1218,CC_scale_factor_volume_scatter,1.863e-06,
 1218,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01219__20140812.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01219__20140812.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1219,CC_dark_counts_volume_scatter,49,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1219,CC_depolarization_ratio,0.039,Constant
 1219,CC_measurement_wavelength,700,Constant
-1219,CC_scale_factor_cdom,0.0905,
+1219,CC_scale_factor_cdom,0.1127562629819091,New cdom scaling factor = old scaling factor (0.0905) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1219,CC_scale_factor_chlorophyll_a,0.0122,
 1219,CC_scale_factor_volume_scatter,1.854e-06,Depth
 1219,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01219__20160516.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01219__20160516.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1219,CC_dark_counts_volume_scatter,70,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1219,CC_depolarization_ratio,0.039,Constant
 1219,CC_measurement_wavelength,700,Constant
-1219,CC_scale_factor_cdom,0.0784,
+1219,CC_scale_factor_cdom,0.1261867467273764,New cdom scaling factor = old scaling factor (0.0784) * scaling factor (5.62) * correction factor (0.28639231863102)
 1219,CC_scale_factor_chlorophyll_a,0.0111,
 1219,CC_scale_factor_volume_scatter,1.981e-06,Depth
 1219,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01219__20180830.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01219__20180830.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1219,CC_dark_counts_volume_scatter,49,
 1219,CC_depolarization_ratio,0.039,Constant
 1219,CC_measurement_wavelength,700,Constant
-1219,CC_scale_factor_cdom,0.0698,
+1219,CC_scale_factor_cdom,0.112344833183302,New cdom scaling factor = old scaling factor (0.0698) * scaling factor (5.62) * correction factor (0.28639231863102)
 1219,CC_scale_factor_chlorophyll_a,0.0102,
 1219,CC_scale_factor_volume_scatter,1.918e-06,
 1219,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01219__20210127.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01219__20210127.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1219,CC_dark_counts_volume_scatter,43,
 1219,CC_depolarization_ratio,0.039,Constant
 1219,CC_measurement_wavelength,700,Constant
-1219,CC_scale_factor_cdom,0.0907,
+1219,CC_scale_factor_cdom,0.3864869154572219,New cdom scaling factor = old scaling factor (0.0907) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1219,CC_scale_factor_chlorophyll_a,0.0123,
 1219,CC_scale_factor_volume_scatter,1.919e-06,
 1219,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01221__20140819.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01221__20140819.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1221,CC_dark_counts_volume_scatter,51,
 1221,CC_depolarization_ratio,0.039,Constant
 1221,CC_measurement_wavelength,700,Constant
-1221,CC_scale_factor_cdom,0.0906,
+1221,CC_scale_factor_cdom,0.1128808555376902,New cdom scaling factor = old scaling factor (0.0906) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1221,CC_scale_factor_chlorophyll_a,0.0122,
 1221,CC_scale_factor_volume_scatter,1.885e-06,
 1221,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01221__20151008.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01221__20151008.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1221,CC_dark_counts_volume_scatter,50,
 1221,CC_depolarization_ratio,0.039,Constant
 1221,CC_measurement_wavelength,700,Constant
-1221,CC_scale_factor_cdom,0.0942,
+1221,CC_scale_factor_cdom,0.1516172390525365,New cdom scaling factor = old scaling factor (0.0942) * scaling factor (5.62) * correction factor (0.28639231863102)
 1221,CC_scale_factor_chlorophyll_a,0.0119,
 1221,CC_scale_factor_volume_scatter,1.888E-06,
 1221,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01221__20160525.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01221__20160525.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1221,CC_dark_counts_volume_scatter,51,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1221,CC_depolarization_ratio,0.039,Constant
 1221,CC_measurement_wavelength,700,Constant
-1221,CC_scale_factor_cdom,0.0797,
+1221,CC_scale_factor_cdom,0.1282791290072947,New cdom scaling factor = old scaling factor (0.0797) * scaling factor (5.62) * correction factor (0.28639231863102)
 1221,CC_scale_factor_chlorophyll_a,0.011,
 1221,CC_scale_factor_volume_scatter,2.04e-06,Depth
 1221,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01221__20180627.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01221__20180627.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1221,CC_dark_counts_volume_scatter,53,
 1221,CC_depolarization_ratio,0.039,Constant
 1221,CC_measurement_wavelength,700,Constant
-1221,CC_scale_factor_cdom,0.0722,
+1221,CC_scale_factor_cdom,0.1162076927769972,New cdom scaling factor = old scaling factor (0.0722) * scaling factor (5.62) * correction factor (0.28639231863102)
 1221,CC_scale_factor_chlorophyll_a,0.0115,
 1221,CC_scale_factor_volume_scatter,2.170e-06,
 1221,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01221__20211223.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01221__20211223.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1221,CC_dark_counts_volume_scatter,51,
 1221,CC_depolarization_ratio,0.039,Constant
 1221,CC_measurement_wavelength,700,Constant
-1221,CC_scale_factor_cdom,9.060E-02,
+1221,CC_scale_factor_cdom,0.3860607997841709,New cdom scaling factor = old scaling factor (0.0906) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1221,CC_scale_factor_chlorophyll_a,1.180E-02,
 1221,CC_scale_factor_volume_scatter,2.136E-06,
 1221,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01222__20140819.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01222__20140819.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1222,CC_dark_counts_volume_scatter,64,
 1222,CC_depolarization_ratio,0.039,Constant
 1222,CC_measurement_wavelength,700,Constant
-1222,CC_scale_factor_cdom,0.0904,
+1222,CC_scale_factor_cdom,0.112631670426128,New cdom scaling factor = old scaling factor (0.0904) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1222,CC_scale_factor_chlorophyll_a,0.0121,
 1222,CC_scale_factor_volume_scatter,1.953e-06,
 1222,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01222__20160112.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01222__20160112.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1222,CC_dark_counts_volume_scatter,66,
 1222,CC_depolarization_ratio,0.039,Constant
 1222,CC_measurement_wavelength,700,
-1222,CC_scale_factor_cdom,0.0797,
+1222,CC_scale_factor_cdom,0.1282791290072947,New cdom scaling factor = old scaling factor (0.0797) * scaling factor (5.62) * correction factor (0.28639231863102)
 1222,CC_scale_factor_chlorophyll_a,0.0119,
 1222,CC_scale_factor_volume_scatter,1.948E-06,
 1222,CC_scattering_angle,124,

--- a/calibration/FLORTD/CGINS-FLORTD-01222__20170105.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01222__20170105.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1222,CC_dark_counts_volume_scatter,64,
 1222,CC_depolarization_ratio,0.039,Constant
 1222,CC_measurement_wavelength,700,Constant
-1222,CC_scale_factor_cdom,0.0792,
+1222,CC_scale_factor_cdom,0.1274743665919415,New cdom scaling factor = old scaling factor (0.0792) * scaling factor (5.62) * correction factor (0.28639231863102)
 1222,CC_scale_factor_chlorophyll_a,0.0119,
 1222,CC_scale_factor_volume_scatter,2.094E-06,
 1222,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01295__20150430.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01295__20150430.csv
@@ -6,7 +6,7 @@ serial,name,value,notes
 Use CTD data from GI01SUMO-RID16-03-CTDBPF000."
 1295,CC_depolarization_ratio,0.039,Constant
 1295,CC_measurement_wavelength,700,Constant
-1295,CC_scale_factor_cdom,0.0905,
+1295,CC_scale_factor_cdom,0.1127562629819091,New cdom scaling factor = old scaling factor (0.0905) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1295,CC_scale_factor_chlorophyll_a,0.0122,
 1295,CC_scale_factor_volume_scatter,1.757e-06,
 1295,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01295__20161013.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01295__20161013.csv
@@ -6,7 +6,7 @@ serial,name,value,notes
 Use CTD data from GI01SUMO-RID16-03-CTDBPF000."
 1295,CC_depolarization_ratio,0.039,Constant
 1295,CC_measurement_wavelength,700,Constant
-1295,CC_scale_factor_cdom,0.0839,
+1295,CC_scale_factor_cdom,0.1350391332962613,New cdom scaling factor = old scaling factor (0.0839) * scaling factor (5.62) * correction factor (0.28639231863102)
 1295,CC_scale_factor_chlorophyll_a,0.012,
 1295,CC_scale_factor_volume_scatter,1.907E-06,
 1295,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01295__20171229.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01295__20171229.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1295,CC_dark_counts_volume_scatter,49,
 1295,CC_depolarization_ratio,0.039,Constant
 1295,CC_measurement_wavelength,700,Constant
-1295,CC_scale_factor_cdom,0.0735,
+1295,CC_scale_factor_cdom,0.1183000750569154,New cdom scaling factor = old scaling factor (0.0735) * scaling factor (5.62) * correction factor (0.28639231863102)
 1295,CC_scale_factor_chlorophyll_a,0.0129,
 1295,CC_scale_factor_volume_scatter,2.132E-06,
 1295,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01295__20220909.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01295__20220909.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1295,CC_dark_counts_volume_scatter,52,
 1295,CC_depolarization_ratio,0.039,Constant
 1295,CC_measurement_wavelength,700,Constant
-1295,CC_scale_factor_cdom,9.062E-02,
+1295,CC_scale_factor_cdom,0.3861460229187812,New cdom scaling factor = old scaling factor (0.09062) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1295,CC_scale_factor_chlorophyll_a,1.218E-02,
 1295,CC_scale_factor_volume_scatter,1.826E-06,
 1295,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01296__20150430.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01296__20150430.csv
@@ -6,7 +6,7 @@ serial,name,value,notes
 Use CTD data from GI01SUMO-SBD11-06-METBKA000 or GI01SUMO-SBD12-06-METBKA000."
 1296,CC_depolarization_ratio,0.039,Constant
 1296,CC_measurement_wavelength,700,Constant
-1296,CC_scale_factor_cdom,0.0906,
+1296,CC_scale_factor_cdom,0.1128808555376902,New cdom scaling factor = old scaling factor (0.0906) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1296,CC_scale_factor_chlorophyll_a,0.0121,
 1296,CC_scale_factor_volume_scatter,1.819e-06,
 1296,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01296__20161014.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01296__20161014.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1296,CC_dark_counts_volume_scatter,58,
 1296,CC_depolarization_ratio,0.039,Constant
 1296,CC_measurement_wavelength,700,Constant
-1296,CC_scale_factor_cdom,0.1,
+1296,CC_scale_factor_cdom,0.1609524830706332,New cdom scaling factor = old scaling factor (0.1) * scaling factor (5.62) * correction factor (0.28639231863102)
 1296,CC_scale_factor_chlorophyll_a,0.0128,
 1296,CC_scale_factor_volume_scatter,1.91E-06,
 1296,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01298__20150512.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01298__20150512.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1298,CC_dark_counts_volume_scatter,46,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1298,CC_depolarization_ratio,0.039,Constant
 1298,CC_measurement_wavelength,700,Constant
-1298,CC_scale_factor_cdom,0.0908,
+1298,CC_scale_factor_cdom,0.1131300406492525,New cdom scaling factor = old scaling factor (0.0908) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1298,CC_scale_factor_chlorophyll_a,0.0121,
 1298,CC_scale_factor_volume_scatter,1.77e-06,Depth
 1298,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01298__20170110.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01298__20170110.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1298,CC_dark_counts_volume_scatter,45,
 1298,CC_depolarization_ratio,0.039,Constant
 1298,CC_measurement_wavelength,700,Constant
-1298,CC_scale_factor_cdom,0.0808,
+1298,CC_scale_factor_cdom,0.1300496063210716,New cdom scaling factor = old scaling factor (0.0808) * scaling factor (5.62) * correction factor (0.28639231863102)
 1298,CC_scale_factor_chlorophyll_a,0.0123,
 1298,CC_scale_factor_volume_scatter,1.79E-06,
 1298,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01298__20240118.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01298__20240118.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1298,CC_dark_counts_volume_scatter,44.5,
 1298,CC_depolarization_ratio,0.039,Constant
 1298,CC_measurement_wavelength,700,Constant
-1298,CC_scale_factor_cdom,9.072E-02,
+1298,CC_scale_factor_cdom,9.072E-02,This calibration not affected by CDOM calibration correction
 1298,CC_scale_factor_chlorophyll_a,1.208E-02,
 1298,CC_scale_factor_volume_scatter,1.809E-06,
 1298,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01299__20150512.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01299__20150512.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1299,CC_dark_counts_volume_scatter,50,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1299,CC_depolarization_ratio,0.039,Constant
 1299,CC_measurement_wavelength,700,Constant
-1299,CC_scale_factor_cdom,0.0906,
+1299,CC_scale_factor_cdom,0.1128808555376902,New cdom scaling factor = old scaling factor (0.0906) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1299,CC_scale_factor_chlorophyll_a,0.0121,
 1299,CC_scale_factor_volume_scatter,1.785e-06,Depth
 1299,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01299__20170110.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01299__20170110.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1299,CC_dark_counts_volume_scatter,50,
 1299,CC_depolarization_ratio,0.039,Constant
 1299,CC_measurement_wavelength,700,Constant
-1299,CC_scale_factor_cdom,0.0776,
+1299,CC_scale_factor_cdom,0.1248991268628114,New cdom scaling factor = old scaling factor (0.0776) * scaling factor (5.62) * correction factor (0.28639231863102)
 1299,CC_scale_factor_chlorophyll_a,0.0118,
 1299,CC_scale_factor_volume_scatter,1.808E-06,
 1299,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01299__20180928.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01299__20180928.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1299,CC_dark_counts_volume_scatter,49,
 1299,CC_depolarization_ratio,0.039,Constant
 1299,CC_measurement_wavelength,700,Constant
-1299,CC_scale_factor_cdom,0.0724,
+1299,CC_scale_factor_cdom,0.1165295977431385,New cdom scaling factor = old scaling factor (0.0724) * scaling factor (5.62) * correction factor (0.28639231863102)
 1299,CC_scale_factor_chlorophyll_a,0.0124,
 1299,CC_scale_factor_volume_scatter,2.001E-06,
 1299,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01299__20210212.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01299__20210212.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1299,CC_dark_counts_volume_scatter,48,
 1299,CC_depolarization_ratio,0.039,Constant
 1299,CC_measurement_wavelength,700,Constant
-1299,CC_scale_factor_cdom,0.0521,
+1299,CC_scale_factor_cdom,0.2220062656595508,New cdom scaling factor = old scaling factor (0.0521) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1299,CC_scale_factor_chlorophyll_a,0.0123,
 1299,CC_scale_factor_volume_scatter,2.201E-06,
 1299,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01299__20220913.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01299__20220913.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1299,CC_dark_counts_volume_scatter,51,
 1299,CC_depolarization_ratio,0.039,Constant
 1299,CC_measurement_wavelength,700,Constant
-1299,CC_scale_factor_cdom,9.139E-02,
+1299,CC_scale_factor_cdom,0.3894271136012735,New cdom scaling factor = old scaling factor (0.09139) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1299,CC_scale_factor_chlorophyll_a,1.208E-02,
 1299,CC_scale_factor_volume_scatter,1.837E-06,
 1299,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01300__20150514.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01300__20150514.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1300,CC_dark_counts_volume_scatter,51,
 1300,CC_depolarization_ratio,0.039,Constant
 1300,CC_measurement_wavelength,700,Constant
-1300,CC_scale_factor_cdom,0.0909,
+1300,CC_scale_factor_cdom,0.1132546332050336,New cdom scaling factor = old scaling factor (0.0909) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1300,CC_scale_factor_chlorophyll_a,0.0122,
 1300,CC_scale_factor_volume_scatter,1.829E-06,
 1300,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01300__20170503.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01300__20170503.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1300,CC_dark_counts_volume_scatter,50,
 1300,CC_depolarization_ratio,0.039,Constant
 1300,CC_measurement_wavelength,700,Constant
-1300,CC_scale_factor_cdom,0.0753,
+1300,CC_scale_factor_cdom,0.1211972197521868,New cdom scaling factor = old scaling factor (0.0753) * scaling factor (5.62) * correction factor (0.28639231863102)
 1300,CC_scale_factor_chlorophyll_a,0.0117,
 1300,CC_scale_factor_volume_scatter,1.921E-06,
 1300,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01300__20200116.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01300__20200116.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1300,CC_dark_counts_volume_scatter,52,
 1300,CC_depolarization_ratio,0.039,Constant
 1300,CC_measurement_wavelength,700,Constant
-1300,CC_scale_factor_cdom,0.0759,
+1300,CC_scale_factor_cdom,0.1901398457318026,New cdom scaling factor = old scaling factor (0.0759) * scaling factor (5.62) * correction factor (0.4457537913526475)
 1300,CC_scale_factor_chlorophyll_a,0.0119,
 1300,CC_scale_factor_volume_scatter,1.907E-06,
 1300,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01300__20240108.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01300__20240108.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1300,CC_dark_counts_volume_scatter,60.025,
 1300,CC_depolarization_ratio,0.039,Constant
 1300,CC_measurement_wavelength,700,Constant
-1300,CC_scale_factor_cdom,9.058E-02,
+1300,CC_scale_factor_cdom,9.058E-02,This calibration not affected by CDOM calibration correction
 1300,CC_scale_factor_chlorophyll_a,1.221E-02,
 1300,CC_scale_factor_volume_scatter,1.914E-06,
 1300,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01301__20150514.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01301__20150514.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1301,CC_dark_counts_volume_scatter,53,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1301,CC_depolarization_ratio,0.039,Constant
 1301,CC_measurement_wavelength,700,Constant
-1301,CC_scale_factor_cdom,0.0914,
+1301,CC_scale_factor_cdom,0.1138775959839392,New cdom scaling factor = old scaling factor (0.0914) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1301,CC_scale_factor_chlorophyll_a,0.0121,
 1301,CC_scale_factor_volume_scatter,1.821e-06,Depth
 1301,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01301__20170505.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01301__20170505.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1301,CC_dark_counts_volume_scatter,53,
 1301,CC_depolarization_ratio,0.039,Constant
 1301,CC_measurement_wavelength,700,Constant
-1301,CC_scale_factor_cdom,0.0795,
+1301,CC_scale_factor_cdom,0.1279572240411534,New cdom scaling factor = old scaling factor (0.0795) * scaling factor (5.62) * correction factor (0.28639231863102)
 1301,CC_scale_factor_chlorophyll_a,0.0121,
 1301,CC_scale_factor_volume_scatter,2.029E-06,
 1301,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01301__20200117.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01301__20200117.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1301,CC_dark_counts_volume_scatter,55,
 1301,CC_depolarization_ratio,0.039,Constant
 1301,CC_measurement_wavelength,700,Constant
-1301,CC_scale_factor_cdom,0.0773,
+1301,CC_scale_factor_cdom,0.1936470365621652,New cdom scaling factor = old scaling factor (0.0773) * scaling factor (5.62) * correction factor (0.4457537913526475)
 1301,CC_scale_factor_chlorophyll_a,0.0114,
 1301,CC_scale_factor_volume_scatter,2.220E-06,
 1301,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01301__20240105.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01301__20240105.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1301,CC_dark_counts_volume_scatter,50,
 1301,CC_depolarization_ratio,0.039,Constant
 1301,CC_measurement_wavelength,700,Constant
-1301,CC_scale_factor_cdom,0.907E-01,
+1301,CC_scale_factor_cdom,0.907E-01,This calibration not affected by CDOM calibration correction
 1301,CC_scale_factor_chlorophyll_a,1.220E-01,
 1301,CC_scale_factor_volume_scatter,1.917E-06,
 1301,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01317__20150710.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01317__20150710.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1317,CC_dark_counts_volume_scatter,50,
 1317,CC_depolarization_ratio,0.039,Constant
 1317,CC_measurement_wavelength,700,Constant
-1317,CC_scale_factor_cdom,0.0921,
+1317,CC_scale_factor_cdom,0.1482372369080532,New cdom scaling factor = old scaling factor (0.0921) * scaling factor (5.62) * correction factor (0.28639231863102)
 1317,CC_scale_factor_chlorophyll_a,0.0121,
 1317,CC_scale_factor_volume_scatter,1.839E-06,
 1317,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01317__20170329.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01317__20170329.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1317,CC_dark_counts_volume_scatter,51,
 1317,CC_depolarization_ratio,0.039,Constant
 1317,CC_measurement_wavelength,700,Constant
-1317,CC_scale_factor_cdom,0.0758,
+1317,CC_scale_factor_cdom,0.12200198216754,New cdom scaling factor = old scaling factor (0.0758) * scaling factor (5.62) * correction factor (0.28639231863102)
 1317,CC_scale_factor_chlorophyll_a,0.0123,
 1317,CC_scale_factor_volume_scatter,2.061E-06,
 1317,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01317__20240105.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01317__20240105.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1317,CC_dark_counts_volume_scatter,48.65,
 1317,CC_depolarization_ratio,0.039,Constant
 1317,CC_measurement_wavelength,700,Constant
-1317,CC_scale_factor_cdom,9.067E-02,
+1317,CC_scale_factor_cdom,9.067E-02,This calibration not affected by CDOM calibration correction
 1317,CC_scale_factor_chlorophyll_a,1.206E-02,
 1317,CC_scale_factor_volume_scatter,1.900E-06,
 1317,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01318__20150710.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01318__20150710.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1318,CC_dark_counts_volume_scatter,51,
 1318,CC_depolarization_ratio,0.039,Constant
 1318,CC_measurement_wavelength,700,Constant
-1318,CC_scale_factor_cdom,0.0901,
+1318,CC_scale_factor_cdom,0.1450181872466405,New cdom scaling factor = old scaling factor (0.0901) * scaling factor (5.62) * correction factor (0.28639231863102)
 1318,CC_scale_factor_chlorophyll_a,0.0121,
 1318,CC_scale_factor_volume_scatter,1.861e-06,
 1318,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01318__20170329.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01318__20170329.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1318,CC_dark_counts_volume_scatter,50,
 1318,CC_depolarization_ratio,0.039,Constant
 1318,CC_measurement_wavelength,700,Constant
-1318,CC_scale_factor_cdom,0.0861,
+1318,CC_scale_factor_cdom,0.1385800879238152,New cdom scaling factor = old scaling factor (0.0861) * scaling factor (5.62) * correction factor (0.28639231863102)
 1318,CC_scale_factor_chlorophyll_a,0.012,
 1318,CC_scale_factor_volume_scatter,2.129E-06,
 1318,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01318__20180928.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01318__20180928.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1318,CC_dark_counts_volume_scatter,51,
 1318,CC_depolarization_ratio,0.039,Constant
 1318,CC_measurement_wavelength,700,Constant
-1318,CC_scale_factor_cdom,0.0807,
+1318,CC_scale_factor_cdom,0.129888653838001,New cdom scaling factor = old scaling factor (0.0807) * scaling factor (5.62) * correction factor (0.28639231863102)
 1318,CC_scale_factor_chlorophyll_a,0.0117,
 1318,CC_scale_factor_volume_scatter,2.163E-06,
 1318,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01318__20210122.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01318__20210122.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1318,CC_dark_counts_volume_scatter,48,
 1318,CC_depolarization_ratio,0.039,Constant
 1318,CC_measurement_wavelength,700,Constant
-1318,CC_scale_factor_cdom,0.0902,
+1318,CC_scale_factor_cdom,0.3843563370919671,New cdom scaling factor = old scaling factor (0.0902) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1318,CC_scale_factor_chlorophyll_a,0.0106,
 1318,CC_scale_factor_volume_scatter,2.405E-06,
 1318,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01318__20220913.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01318__20220913.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1318,CC_dark_counts_volume_scatter,62,
 1318,CC_depolarization_ratio,0.039,Constant
 1318,CC_measurement_wavelength,700,Constant
-1318,CC_scale_factor_cdom,9.121E-02,
+1318,CC_scale_factor_cdom,0.3886601053897818,New cdom scaling factor = old scaling factor (0.09121) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1318,CC_scale_factor_chlorophyll_a,1.215E-02,
 1318,CC_scale_factor_volume_scatter,1.846E-06,
 1318,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01319__20150710.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01319__20150710.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1319,CC_dark_counts_volume_scatter,50,
 1319,CC_depolarization_ratio,0.039,Constant
 1319,CC_measurement_wavelength,700,Constant
-1319,CC_scale_factor_cdom,0.092,
+1319,CC_scale_factor_cdom,0.1480762844249826,New cdom scaling factor = old scaling factor (0.092) * scaling factor (5.62) * correction factor (0.28639231863102)
 1319,CC_scale_factor_chlorophyll_a,0.0121,
 1319,CC_scale_factor_volume_scatter,1.86e-06,
 1319,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01319__20170320.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01319__20170320.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1319,CC_dark_counts_volume_scatter,50,
 1319,CC_depolarization_ratio,0.039,Constant
 1319,CC_measurement_wavelength,700,Constant
-1319,CC_scale_factor_cdom,0.0816,
+1319,CC_scale_factor_cdom,0.1313372261856367,New cdom scaling factor = old scaling factor (0.0816) * scaling factor (5.62) * correction factor (0.28639231863102)
 1319,CC_scale_factor_chlorophyll_a,0.0124,
 1319,CC_scale_factor_volume_scatter,2.126E-06,
 1319,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01319__20200401.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01319__20200401.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1319,CC_dark_counts_volume_scatter,52,
 1319,CC_depolarization_ratio,0.039,Constant
 1319,CC_measurement_wavelength,700,Constant
-1319,CC_scale_factor_cdom,0.0663,
+1319,CC_scale_factor_cdom,0.2825146912327873,New cdom scaling factor = old scaling factor (0.0663) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1319,CC_scale_factor_chlorophyll_a,0.0113,
 1319,CC_scale_factor_volume_scatter,1.871E-06,
 1319,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01319__20220105.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01319__20220105.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1319,CC_dark_counts_volume_scatter,49,
 1319,CC_depolarization_ratio,0.039,Constant
 1319,CC_measurement_wavelength,700,Constant
-1319,CC_scale_factor_cdom,9.050E-02,
+1319,CC_scale_factor_cdom,0.38563468411112,New cdom scaling factor = old scaling factor (0.0905) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1319,CC_scale_factor_chlorophyll_a,1.080E-02,
 1319,CC_scale_factor_volume_scatter,2.126E-06,
 1319,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01320__20150707.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01320__20150707.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1320,CC_dark_counts_volume_scatter,49,
 1320,CC_depolarization_ratio,0.039,Constant
 1320,CC_measurement_wavelength,700,Constant
-1320,CC_scale_factor_cdom,0.0898,
+1320,CC_scale_factor_cdom,0.1445353297974286,New cdom scaling factor = old scaling factor (0.0898) * scaling factor (5.62) * correction factor (0.28639231863102)
 1320,CC_scale_factor_chlorophyll_a,0.0121,
 1320,CC_scale_factor_volume_scatter,1.848e-06,
 1320,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01320__20170320.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01320__20170320.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1320,CC_dark_counts_volume_scatter,50,
 1320,CC_depolarization_ratio,0.039,Constant
 1320,CC_measurement_wavelength,700,Constant
-1320,CC_scale_factor_cdom,0.0794,
+1320,CC_scale_factor_cdom,0.1277962715580828,New cdom scaling factor = old scaling factor (0.0794) * scaling factor (5.62) * correction factor (0.28639231863102)
 1320,CC_scale_factor_chlorophyll_a,0.0124,
 1320,CC_scale_factor_volume_scatter,2.258E-06,
 1320,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01320__20200401.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01320__20200401.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1320,CC_dark_counts_volume_scatter,52,
 1320,CC_depolarization_ratio,0.039,Constant
 1320,CC_measurement_wavelength,700,Constant
-1320,CC_scale_factor_cdom,0.0679,
+1320,CC_scale_factor_cdom,0.2893325420016027,New cdom scaling factor = old scaling factor (0.0679) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1320,CC_scale_factor_chlorophyll_a,0.0116,
 1320,CC_scale_factor_volume_scatter,1.994E-06,
 1320,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01320__20211229.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01320__20211229.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1320,CC_dark_counts_volume_scatter,50,
 1320,CC_depolarization_ratio,0.039,Constant
 1320,CC_measurement_wavelength,700,Constant
-1320,CC_scale_factor_cdom,9.080E-02,
+1320,CC_scale_factor_cdom,0.3869130311302729,New cdom scaling factor = old scaling factor (0.0908) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1320,CC_scale_factor_chlorophyll_a,1.070E-02,
 1320,CC_scale_factor_volume_scatter,2.416E-06,
 1320,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01321__20150729.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01321__20150729.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1321,CC_dark_counts_volume_scatter,50,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1321,CC_depolarization_ratio,0.039,Constant
 1321,CC_measurement_wavelength,700,Constant
-1321,CC_scale_factor_cdom,0.0903,
+1321,CC_scale_factor_cdom,0.1453400922127818,New cdom scaling factor = old scaling factor (0.0903) * scaling factor (5.62) * correction factor (0.28639231863102)
 1321,CC_scale_factor_chlorophyll_a,0.0121,
 1321,CC_scale_factor_volume_scatter,1.845e-06,Depth
 1321,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01321__20170412.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01321__20170412.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1321,CC_dark_counts_volume_scatter,50,
 1321,CC_depolarization_ratio,0.039,Constant
 1321,CC_measurement_wavelength,700,Constant
-1321,CC_scale_factor_cdom,0.0863,
+1321,CC_scale_factor_cdom,0.1389019928899565,New cdom scaling factor = old scaling factor (0.0863) * scaling factor (5.62) * correction factor (0.28639231863102)
 1321,CC_scale_factor_chlorophyll_a,0.0122,
 1321,CC_scale_factor_volume_scatter,1.996E-06,
 1321,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01321__20211223.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01321__20211223.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1321,CC_dark_counts_volume_scatter,50,
 1321,CC_depolarization_ratio,0.039,Constant
 1321,CC_measurement_wavelength,700,Constant
-1321,CC_scale_factor_cdom,9.060E-02,
+1321,CC_scale_factor_cdom,0.3860607997841709,New cdom scaling factor = old scaling factor (0.0906) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1321,CC_scale_factor_chlorophyll_a,1.760E-02,
 1321,CC_scale_factor_volume_scatter,1.868E-06,
 1321,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01322__20150729.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01322__20150729.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1322,CC_dark_counts_volume_scatter,47,Requires TEMPWAT and PRACSAL (PD2927/2929) from a nearby CTD
 1322,CC_depolarization_ratio,0.039,Constant
 1322,CC_measurement_wavelength,700,Constant
-1322,CC_scale_factor_cdom,0.0903,
+1322,CC_scale_factor_cdom,0.1453400922127818,New cdom scaling factor = old scaling factor (0.0903) * scaling factor (5.62) * correction factor (0.28639231863102)
 1322,CC_scale_factor_chlorophyll_a,0.0121,
 1322,CC_scale_factor_volume_scatter,1.845e-06,Depth
 1322,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01322__20170412.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01322__20170412.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1322,CC_dark_counts_volume_scatter,47,
 1322,CC_depolarization_ratio,0.039,Constant
 1322,CC_measurement_wavelength,700,Constant
-1322,CC_scale_factor_cdom,0.0843,
+1322,CC_scale_factor_cdom,0.1356829432285438,New cdom scaling factor = old scaling factor (0.0843) * scaling factor (5.62) * correction factor (0.28639231863102)
 1322,CC_scale_factor_chlorophyll_a,0.012,
 1322,CC_scale_factor_volume_scatter,2.0040E-06,
 1322,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01322__20180822.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01322__20180822.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1322,CC_dark_counts_volume_scatter,50,
 1322,CC_depolarization_ratio,0.039,Constant
 1322,CC_measurement_wavelength,700,Constant
-1322,CC_scale_factor_cdom,0.0728,
+1322,CC_scale_factor_cdom,0.117173407675421,New cdom scaling factor = old scaling factor (0.0728) * scaling factor (5.62) * correction factor (0.28639231863102)
 1322,CC_scale_factor_chlorophyll_a,0.0115,
 1322,CC_scale_factor_volume_scatter,2.129E-06,
 1322,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01322__20220912.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01322__20220912.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1322,CC_dark_counts_volume_scatter,51,
 1322,CC_depolarization_ratio,0.039,Constant
 1322,CC_measurement_wavelength,700,Constant
-1322,CC_scale_factor_cdom,8.968E-02,
+1322,CC_scale_factor_cdom,0.382140535592102,New cdom scaling factor = old scaling factor (0.08968) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1322,CC_scale_factor_chlorophyll_a,1.207E-02,
 1322,CC_scale_factor_volume_scatter,1.817E-06,
 1322,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01323__20150729.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01323__20150729.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1323,CC_dark_counts_volume_scatter,51,
 1323,CC_depolarization_ratio,0.039,Constant
 1323,CC_measurement_wavelength,700,
-1323,CC_scale_factor_cdom,0.0907,
+1323,CC_scale_factor_cdom,0.1459839021450643,New cdom scaling factor = old scaling factor (0.0907) * scaling factor (5.62) * correction factor (0.28639231863102)
 1323,CC_scale_factor_chlorophyll_a,0.0121,
 1323,CC_scale_factor_volume_scatter,1.868E-06,
 1323,CC_scattering_angle,124,

--- a/calibration/FLORTD/CGINS-FLORTD-01323__20160802.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01323__20160802.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1323,CC_dark_counts_volume_scatter,54,
 1323,CC_depolarization_ratio,0.039,Constant
 1323,CC_measurement_wavelength,700,Constant
-1323,CC_scale_factor_cdom,0.085,
+1323,CC_scale_factor_cdom,0.1368096106100383,New cdom scaling factor = old scaling factor (0.085) * scaling factor (5.62) * correction factor (0.28639231863102)
 1323,CC_scale_factor_chlorophyll_a,0.0119,
 1323,CC_scale_factor_volume_scatter,1.954e-06,
 1323,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01323__20170802.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01323__20170802.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1323,CC_dark_counts_volume_scatter,53,
 1323,CC_depolarization_ratio,0.039,Constant
 1323,CC_measurement_wavelength,700,Constant
-1323,CC_scale_factor_cdom,0.0782,
+1323,CC_scale_factor_cdom,0.1258648417612352,New cdom scaling factor = old scaling factor (0.0782) * scaling factor (5.62) * correction factor (0.28639231863102)
 1323,CC_scale_factor_chlorophyll_a,0.0122,
 1323,CC_scale_factor_volume_scatter,2.297E-06,
 1323,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01323__20200129.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01323__20200129.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1323,CC_dark_counts_volume_scatter,51,
 1323,CC_depolarization_ratio,0.039,Constant
 1323,CC_measurement_wavelength,700,Constant
-1323,CC_scale_factor_cdom,0.0665,
+1323,CC_scale_factor_cdom,0.1665915644422249,New cdom scaling factor = old scaling factor (0.0665) * scaling factor (5.62) * correction factor (0.4457537913526475)
 1323,CC_scale_factor_chlorophyll_a,0.0117,
 1323,CC_scale_factor_volume_scatter,2.407E-06,
 1323,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01323__20240109.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01323__20240109.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1323,CC_dark_counts_volume_scatter,56.875,
 1323,CC_depolarization_ratio,0.039,Constant
 1323,CC_measurement_wavelength,700,Constant
-1323,CC_scale_factor_cdom,9.132E-02,
+1323,CC_scale_factor_cdom,9.132E-02,This calibration not affected by CDOM calibration correction
 1323,CC_scale_factor_chlorophyll_a,1.210E-02,
 1323,CC_scale_factor_volume_scatter,1.890E-06,
 1323,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01324__20150729.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01324__20150729.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1324,CC_dark_counts_volume_scatter,49,
 1324,CC_depolarization_ratio,0.039,Constant
 1324,CC_measurement_wavelength,700,Constant
-1324,CC_scale_factor_cdom,0.0906,
+1324,CC_scale_factor_cdom,0.1458229496619937,New cdom scaling factor = old scaling factor (0.0906) * scaling factor (5.62) * correction factor (0.28639231863102)
 1324,CC_scale_factor_chlorophyll_a,0.0121,
 1324,CC_scale_factor_volume_scatter,1.931e-06,
 1324,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01324__20160802.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01324__20160802.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1324,CC_dark_counts_volume_scatter,51,
 1324,CC_depolarization_ratio,0.039,Constant
 1324,CC_measurement_wavelength,700,Constant
-1324,CC_scale_factor_cdom,0.0829,
+1324,CC_scale_factor_cdom,0.133429608465555,New cdom scaling factor = old scaling factor (0.0829) * scaling factor (5.62) * correction factor (0.28639231863102)
 1324,CC_scale_factor_chlorophyll_a,0.0118,
 1324,CC_scale_factor_volume_scatter,1.988E-06,
 1324,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01324__20170803.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01324__20170803.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1324,CC_dark_counts_volume_scatter,51,
 1324,CC_depolarization_ratio,0.039,Constant
 1324,CC_measurement_wavelength,700,Constant
-1324,CC_scale_factor_cdom,0.0748,
+1324,CC_scale_factor_cdom,0.1203924573368337,New cdom scaling factor = old scaling factor (0.0748) * scaling factor (5.62) * correction factor (0.28639231863102)
 1324,CC_scale_factor_chlorophyll_a,0.0117,
 1324,CC_scale_factor_volume_scatter,2.334E-06,
 1324,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01324__20200117.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01324__20200117.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1324,CC_dark_counts_volume_scatter,50,
 1324,CC_depolarization_ratio,0.039,Constant
 1324,CC_measurement_wavelength,700,Constant
-1324,CC_scale_factor_cdom,0.0662,
+1324,CC_scale_factor_cdom,0.1658400235500043,New cdom scaling factor = old scaling factor (0.0662) * scaling factor (5.62) * correction factor (0.4457537913526475)
 1324,CC_scale_factor_chlorophyll_a,0.0110,
 1324,CC_scale_factor_volume_scatter,2.469E-06,
 1324,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01324__20240422.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01324__20240422.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1324,CC_dark_counts_volume_scatter,47.125,
 1324,CC_depolarization_ratio,0.039,Constant
 1324,CC_measurement_wavelength,700,Constant
-1324,CC_scale_factor_cdom,9.099E-02,
+1324,CC_scale_factor_cdom,9.099E-02,This calibration not affected by CDOM calibration correction
 1324,CC_scale_factor_chlorophyll_a,1.209E-02,
 1324,CC_scale_factor_volume_scatter,1.780E-06,
 1324,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01435__20160422.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01435__20160422.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1435,CC_dark_counts_volume_scatter,50,
 1435,CC_depolarization_ratio,0.039,Constant
 1435,CC_measurement_wavelength,700,Constant
-1435,CC_scale_factor_cdom,0.0906,
+1435,CC_scale_factor_cdom,0.1458229496619937,New cdom scaling factor = old scaling factor (0.0906) * scaling factor (5.62) * correction factor (0.28639231863102)
 1435,CC_scale_factor_chlorophyll_a,0.0073,
 1435,CC_scale_factor_volume_scatter,1.786E-06,
 1435,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01435__20220202.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01435__20220202.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1435,CC_dark_counts_volume_scatter,49.375,
 1435,CC_depolarization_ratio,0.039,Constant
 1435,CC_measurement_wavelength,700,Constant
-1435,CC_scale_factor_cdom,7.627E-02,
+1435,CC_scale_factor_cdom,0.3249984238359682,New cdom scaling factor = old scaling factor (0.07627) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1435,CC_scale_factor_chlorophyll_a,7.277E-03,
 1435,CC_scale_factor_volume_scatter,1.964E-06,
 1435,CC_scattering_angle,124,Constant

--- a/calibration/FLORTJ/CGINS-FLORTJ-01205__20140610.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01205__20140610.csv
@@ -5,7 +5,7 @@ BBFL2W-1205,CC_dark_counts_chlorophyll_a,46,Measured signal output of fluormeter
 BBFL2W-1205,CC_dark_counts_volume_scatter,49,Measured signal output of fluormeter in clean water with black tape over the detector [counts]
 BBFL2W-1205,CC_depolarization_ratio,0.039,Depolarization ratio [unitless].
 BBFL2W-1205,CC_measurement_wavelength,700,Optical backscatter measurement wavelength [nm].
-BBFL2W-1205,CC_scale_factor_cdom,0.0903,Multiplier [ppb counts^-1]
+BBFL2W-1205,CC_scale_factor_cdom,0.1125070778703469,New cdom scaling factor = old scaling factor (0.0903) * scaling factor (5.62) * correction factor (0.2216949391123044)
 BBFL2W-1205,CC_scale_factor_chlorophyll_a,0.0121,Multiplier [ug L^-1 counts^-1]
 BBFL2W-1205,CC_scale_factor_volume_scatter,3.063e-06,Multiplier [m^-1 sr^-1 counts^-1]
 BBFL2W-1205,CC_scattering_angle,124,Optical backscatter scattering angle [degrees].

--- a/calibration/FLORTJ/CGINS-FLORTJ-01208__20140610.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01208__20140610.csv
@@ -5,7 +5,7 @@ BBFL2W-1208,CC_dark_counts_chlorophyll_a,47,Measured signal output of fluormeter
 BBFL2W-1208,CC_dark_counts_volume_scatter,50,Measured signal output of fluormeter in clean water with black tape over the detector [counts]
 BBFL2W-1208,CC_depolarization_ratio,0.039,Depolarization ratio [unitless].
 BBFL2W-1208,CC_measurement_wavelength,700,Optical backscatter measurement wavelength [nm].
-BBFL2W-1208,CC_scale_factor_cdom,0.0903,Multiplier [ppb counts^-1]
+BBFL2W-1208,CC_scale_factor_cdom,0.1125070778703469,New cdom scaling factor = old scaling factor (0.0903) * scaling factor (5.62) * correction factor (0.2216949391123044)
 BBFL2W-1208,CC_scale_factor_chlorophyll_a,0.0121,Multiplier [ug L^-1 counts^-1]
 BBFL2W-1208,CC_scale_factor_volume_scatter,3.092e-06,Multiplier [m^-1 sr^-1 counts^-1]
 BBFL2W-1208,CC_scattering_angle,124,Optical backscatter scattering angle [degrees].

--- a/calibration/FLORTJ/CGINS-FLORTJ-01208__20160219.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01208__20160219.csv
@@ -5,7 +5,7 @@ BBFL2W-1208,CC_dark_counts_chlorophyll_a,51,Measured signal output of fluormeter
 BBFL2W-1208,CC_dark_counts_volume_scatter,53,Measured signal output of fluormeter in clean water with black tape over the detector [counts]
 BBFL2W-1208,CC_depolarization_ratio,0.039,Depolarization ratio [unitless].
 BBFL2W-1208,CC_measurement_wavelength,700,Optical backscatter measurement wavelength [nm].
-BBFL2W-1208,CC_scale_factor_cdom,0.1007,Multiplier [ppb counts^-1]
+BBFL2W-1208,CC_scale_factor_cdom,0.1620791504521277,New cdom scaling factor = old scaling factor (0.1007) * scaling factor (5.62) * correction factor (0.28639231863102)
 BBFL2W-1208,CC_scale_factor_chlorophyll_a,0.0124,Multiplier [ug L^-1 counts^-1]
 BBFL2W-1208,CC_scale_factor_volume_scatter,3.11e-06,Multiplier [m^-1 sr^-1 counts^-1]
 BBFL2W-1208,CC_scattering_angle,124,Optical backscatter scattering angle [degrees].

--- a/calibration/FLORTJ/CGINS-FLORTJ-01208__20230920.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01208__20230920.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1208,CC_dark_counts_cdom,47,date in filename comes from dev file
-BBFL2W-1208,CC_scale_factor_cdom,1.098E-01,
+BBFL2W-1208,CC_scale_factor_cdom,1.098E-01,This calibration not affected by CDOM calibration correction
 BBFL2W-1208,CC_dark_counts_chlorophyll_a,46,
 BBFL2W-1208,CC_scale_factor_chlorophyll_a,1.208E-02,
 BBFL2W-1208,CC_dark_counts_volume_scatter,50.5,

--- a/calibration/FLORTK/CGINS-FLORTK-00830__20110405.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-00830__20110405.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 830,CC_dark_counts_volume_scatter,48.0,
 830,CC_depolarization_ratio,0.039,
 830,CC_measurement_wavelength,700.0,
-830,CC_scale_factor_cdom,0.092,
+830,CC_scale_factor_cdom,0.1536268014142858,New cdom scaling factor = old scaling factor (0.092) * scaling factor (5.62) * correction factor (0.2971274977067264)
 830,CC_scale_factor_chlorophyll_a,0.0122,
 830,CC_scale_factor_volume_scatter,2.12e-06,
 830,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-00830__20150211.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-00830__20150211.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 830,CC_dark_counts_volume_scatter,47.0,
 830,CC_depolarization_ratio,0.039,
 830,CC_measurement_wavelength,700.0,
-830,CC_scale_factor_cdom,0.0744,
+830,CC_scale_factor_cdom,0.0926968615011496,New cdom scaling factor = old scaling factor (0.0744) * scaling factor (5.62) * correction factor (0.2216949391123044)
 830,CC_scale_factor_chlorophyll_a,0.0121,
 830,CC_scale_factor_volume_scatter,2.264e-06,
 830,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-00830__20160715.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-00830__20160715.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 830,CC_dark_counts_volume_scatter,46.0,
 830,CC_depolarization_ratio,0.039,
 830,CC_measurement_wavelength,700.0,
-830,CC_scale_factor_cdom,0.0656,
+830,CC_scale_factor_cdom,0.1055848288943354,New cdom scaling factor = old scaling factor (0.0656) * scaling factor (5.62) * correction factor (0.28639231863102)
 830,CC_scale_factor_chlorophyll_a,0.0121,
 830,CC_scale_factor_volume_scatter,2.192e-06,
 830,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-00830__20170726.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-00830__20170726.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 830,CC_dark_counts_volume_scatter,48,
 830,CC_depolarization_ratio,0.039,
 830,CC_measurement_wavelength,700,
-830,CC_scale_factor_cdom,0.0605,
+830,CC_scale_factor_cdom,0.0973762522577331,New cdom scaling factor = old scaling factor (0.0605) * scaling factor (5.62) * correction factor (0.28639231863102)
 830,CC_scale_factor_chlorophyll_a,0.0119,
 830,CC_scale_factor_volume_scatter,2.46E-06,
 830,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-00830__20180628.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-00830__20180628.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 830,CC_dark_counts_volume_scatter,47,
 830,CC_depolarization_ratio,0.039,
 830,CC_measurement_wavelength,700,
-830,CC_scale_factor_cdom,0.0606,
+830,CC_scale_factor_cdom,0.0975372047408037,New cdom scaling factor = old scaling factor (0.0606) * scaling factor (5.62) * correction factor (0.28639231863102)
 830,CC_scale_factor_chlorophyll_a,0.0123,
 830,CC_scale_factor_volume_scatter,2.470E-06,
 830,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-00830__20190617.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-00830__20190617.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 830,CC_dark_counts_volume_scatter,47,
 830,CC_depolarization_ratio,0.039,
 830,CC_measurement_wavelength,700,
-830,CC_scale_factor_cdom,0.2016,
+830,CC_scale_factor_cdom,0.5050354795722187,New cdom scaling factor = old scaling factor (0.2016) * scaling factor (5.62) * correction factor (0.4457537913526475)
 830,CC_scale_factor_chlorophyll_a,0.0120,
 830,CC_scale_factor_volume_scatter,2.2170E-06,
 830,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-00830__20200724.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-00830__20200724.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 830,CC_dark_counts_volume_scatter,45,
 830,CC_depolarization_ratio,0.039,
 830,CC_measurement_wavelength,700,
-830,CC_scale_factor_cdom,0.0893,
+830,CC_scale_factor_cdom,0.3805212960345084,New cdom scaling factor = old scaling factor (0.0893) * scaling factor (5.62) * correction factor (0.7582129413718173)
 830,CC_scale_factor_chlorophyll_a,0.0122,
 830,CC_scale_factor_volume_scatter,2.764E-06,
 830,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-00830__20230320.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-00830__20230320.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 830,CC_dark_counts_volume_scatter,47,
 830,CC_depolarization_ratio,0.039,
 830,CC_measurement_wavelength,700,
-830,CC_scale_factor_cdom,9.050E-02,
+830,CC_scale_factor_cdom,9.050E-02,This calibration not affected by CDOM calibration correction
 830,CC_scale_factor_chlorophyll_a,1.237E-02,
 830,CC_scale_factor_volume_scatter,2.652E-06,
 830,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-00969__20120717.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-00969__20120717.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 969,CC_dark_counts_volume_scatter,49.0,
 969,CC_depolarization_ratio,0.039,
 969,CC_measurement_wavelength,700.0,
-969,CC_scale_factor_cdom,0.0911,
+969,CC_scale_factor_cdom,0.1521239305308852,New cdom scaling factor = old scaling factor (0.0911) * scaling factor (5.62) * correction factor (0.2971274977067264)
 969,CC_scale_factor_chlorophyll_a,0.0121,
 969,CC_scale_factor_volume_scatter,3.356e-06,
 969,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-00969__20140814.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-00969__20140814.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 969,CC_dark_counts_volume_scatter,49.0,
 969,CC_depolarization_ratio,0.039,
 969,CC_measurement_wavelength,700.0,
-969,CC_scale_factor_cdom,0.0917,
+969,CC_scale_factor_cdom,0.1142513736512825,New cdom scaling factor = old scaling factor (0.0917) * scaling factor (5.62) * correction factor (0.2216949391123044)
 969,CC_scale_factor_chlorophyll_a,0.0116,
 969,CC_scale_factor_volume_scatter,3.507e-06,
 969,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-00969__20150818.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-00969__20150818.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 969,CC_dark_counts_volume_scatter,49.0,
 969,CC_depolarization_ratio,0.039,
 969,CC_measurement_wavelength,700.0,
-969,CC_scale_factor_cdom,0.0792,
+969,CC_scale_factor_cdom,0.1274743665919415,New cdom scaling factor = old scaling factor (0.0792) * scaling factor (5.62) * correction factor (0.28639231863102)
 969,CC_scale_factor_chlorophyll_a,0.0119,
 969,CC_scale_factor_volume_scatter,3.448e-06,
 969,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-00969__20161212.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-00969__20161212.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 969,CC_dark_counts_volume_scatter,48,
 969,CC_depolarization_ratio,0.039,
 969,CC_measurement_wavelength,700,
-969,CC_scale_factor_cdom,0.0613,
+969,CC_scale_factor_cdom,0.0986638721222982,New cdom scaling factor = old scaling factor (0.0613) * scaling factor (5.62) * correction factor (0.28639231863102)
 969,CC_scale_factor_chlorophyll_a,0.0118,
 969,CC_scale_factor_volume_scatter,3.307E-06,
 969,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-00969__20180126.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-00969__20180126.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 969,CC_dark_counts_volume_scatter,50,
 969,CC_depolarization_ratio,0.039,
 969,CC_measurement_wavelength,700,
-969,CC_scale_factor_cdom,0.0553,
+969,CC_scale_factor_cdom,0.0890067231380602,New cdom scaling factor = old scaling factor (0.0553) * scaling factor (5.62) * correction factor (0.28639231863102)
 969,CC_scale_factor_chlorophyll_a,0.0118,
 969,CC_scale_factor_volume_scatter,3.681E-06,
 969,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-00969__20190111.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-00969__20190111.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 969,CC_dark_counts_volume_scatter,49,
 969,CC_depolarization_ratio,0.039,
 969,CC_measurement_wavelength,700,
-969,CC_scale_factor_cdom,0.0500,
+969,CC_scale_factor_cdom,0.0804762415353166,New cdom scaling factor = old scaling factor (0.05) * scaling factor (5.62) * correction factor (0.28639231863102)
 969,CC_scale_factor_chlorophyll_a,0.0116,
 969,CC_scale_factor_volume_scatter,3.683E-06,
 969,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-00969__20191210.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-00969__20191210.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 969,CC_dark_counts_volume_scatter,49,
 969,CC_depolarization_ratio,0.039,
 969,CC_measurement_wavelength,700,
-969,CC_scale_factor_cdom,0.0487,
+969,CC_scale_factor_cdom,0.1220001381704714,New cdom scaling factor = old scaling factor (0.0487) * scaling factor (5.62) * correction factor (0.4457537913526475)
 969,CC_scale_factor_chlorophyll_a,0.0115,
 969,CC_scale_factor_volume_scatter,3.690E-06,
 969,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01029__20121211.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01029__20121211.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1029,CC_dark_counts_volume_scatter,50.0,
 1029,CC_depolarization_ratio,0.039,
 1029,CC_measurement_wavelength,700.0,
-1029,CC_scale_factor_cdom,0.0907,
+1029,CC_scale_factor_cdom,0.1514559879160404,New cdom scaling factor = old scaling factor (0.0907) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1029,CC_scale_factor_chlorophyll_a,0.0121,
 1029,CC_scale_factor_volume_scatter,3.49e-06,
 1029,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01029__20140814.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01029__20140814.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1029,CC_dark_counts_volume_scatter,49.0,
 1029,CC_depolarization_ratio,0.039,
 1029,CC_measurement_wavelength,700.0,
-1029,CC_scale_factor_cdom,0.0787,
+1029,CC_scale_factor_cdom,0.0980543413997376,New cdom scaling factor = old scaling factor (0.0787) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1029,CC_scale_factor_chlorophyll_a,0.0117,
 1029,CC_scale_factor_volume_scatter,3.338e-06,
 1029,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01029__20150812.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01029__20150812.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1029,CC_dark_counts_volume_scatter,48.0,
 1029,CC_depolarization_ratio,0.039,
 1029,CC_measurement_wavelength,700.0,
-1029,CC_scale_factor_cdom,0.0755,
+1029,CC_scale_factor_cdom,0.1215191247183281,New cdom scaling factor = old scaling factor (0.0755) * scaling factor (5.62) * correction factor (0.28639231863102)
 1029,CC_scale_factor_chlorophyll_a,0.0119,
 1029,CC_scale_factor_volume_scatter,3.328e-06,
 1029,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01029__20160714.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01029__20160714.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1029,CC_dark_counts_volume_scatter,49.0,
 1029,CC_depolarization_ratio,0.039,
 1029,CC_measurement_wavelength,700.0,
-1029,CC_scale_factor_cdom,0.0755,
+1029,CC_scale_factor_cdom,0.1215191247183281,New cdom scaling factor = old scaling factor (0.0755) * scaling factor (5.62) * correction factor (0.28639231863102)
 1029,CC_scale_factor_chlorophyll_a,0.0108,
 1029,CC_scale_factor_volume_scatter,3.300e-06,
 1029,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01029__20170725.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01029__20170725.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1029,CC_dark_counts_volume_scatter,48,
 1029,CC_depolarization_ratio,0.039,
 1029,CC_measurement_wavelength,700,
-1029,CC_scale_factor_cdom,0.0597,
+1029,CC_scale_factor_cdom,0.096088632393168,New cdom scaling factor = old scaling factor (0.0597) * scaling factor (5.62) * correction factor (0.28639231863102)
 1029,CC_scale_factor_chlorophyll_a,0.0108,
 1029,CC_scale_factor_volume_scatter,3.687E-06,
 1029,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01029__20180628.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01029__20180628.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1029,CC_dark_counts_volume_scatter,48,
 1029,CC_depolarization_ratio,0.039,
 1029,CC_measurement_wavelength,700,
-1029,CC_scale_factor_cdom,0.0637,
+1029,CC_scale_factor_cdom,0.1025267317159934,New cdom scaling factor = old scaling factor (0.0637) * scaling factor (5.62) * correction factor (0.28639231863102)
 1029,CC_scale_factor_chlorophyll_a,0.0109,
 1029,CC_scale_factor_volume_scatter,3.692E-06,
 1029,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01029__20190617.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01029__20190617.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1029,CC_dark_counts_volume_scatter,48,
 1029,CC_depolarization_ratio,0.039,
 1029,CC_measurement_wavelength,700,
-1029,CC_scale_factor_cdom,0.0643,
+1029,CC_scale_factor_cdom,0.1610802645659408,New cdom scaling factor = old scaling factor (0.0643) * scaling factor (5.62) * correction factor (0.4457537913526475)
 1029,CC_scale_factor_chlorophyll_a,0.0143,
 1029,CC_scale_factor_volume_scatter,3.332E-06,
 1029,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01029__20200727.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01029__20200727.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1029,CC_dark_counts_volume_scatter,48,
 1029,CC_depolarization_ratio,0.039,
 1029,CC_measurement_wavelength,700,
-1029,CC_scale_factor_cdom,0.0555,
+1029,CC_scale_factor_cdom,0.2364941985432835,New cdom scaling factor = old scaling factor (0.0555) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1029,CC_scale_factor_chlorophyll_a,0.0104,
 1029,CC_scale_factor_volume_scatter,3.720E-06,
 1029,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01029__20230203.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01029__20230203.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1029,CC_dark_counts_volume_scatter,50,
 1029,CC_depolarization_ratio,0.039,
 1029,CC_measurement_wavelength,700,
-1029,CC_scale_factor_cdom,1.070E-01,
+1029,CC_scale_factor_cdom,1.070E-01,This calibration not affected by CDOM calibration correction
 1029,CC_scale_factor_chlorophyll_a,1.158E-02,
 1029,CC_scale_factor_volume_scatter,3.366E-06,
 1029,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01031__20121212.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01031__20121212.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1031,CC_dark_counts_volume_scatter,51.0,
 1031,CC_depolarization_ratio,0.039,
 1031,CC_measurement_wavelength,700.0,
-1031,CC_scale_factor_cdom,0.0907,
+1031,CC_scale_factor_cdom,0.1514559879160404,New cdom scaling factor = old scaling factor (0.0907) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1031,CC_scale_factor_chlorophyll_a,0.0121,
 1031,CC_scale_factor_volume_scatter,3.53e-06,
 1031,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01031__20140814.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01031__20140814.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1031,CC_dark_counts_volume_scatter,49.0,
 1031,CC_depolarization_ratio,0.039,
 1031,CC_measurement_wavelength,700.0,
-1031,CC_scale_factor_cdom,0.0838,
+1031,CC_scale_factor_cdom,0.1044085617445744,New cdom scaling factor = old scaling factor (0.0838) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1031,CC_scale_factor_chlorophyll_a,0.0116,
 1031,CC_scale_factor_volume_scatter,3.210e-06,
 1031,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01031__20151230.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01031__20151230.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1031,CC_dark_counts_volume_scatter,49.0,
 1031,CC_depolarization_ratio,0.039,
 1031,CC_measurement_wavelength,700.0,
-1031,CC_scale_factor_cdom,0.0723,
+1031,CC_scale_factor_cdom,0.1163686452600678,New cdom scaling factor = old scaling factor (0.0723) * scaling factor (5.62) * correction factor (0.28639231863102)
 1031,CC_scale_factor_chlorophyll_a,0.011,
 1031,CC_scale_factor_volume_scatter,3.154e-06,
 1031,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01031__20170726.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01031__20170726.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1031,CC_dark_counts_volume_scatter,49,
 1031,CC_depolarization_ratio,0.039,
 1031,CC_measurement_wavelength,700,
-1031,CC_scale_factor_cdom,0.0983,
+1031,CC_scale_factor_cdom,0.1582162908584325,New cdom scaling factor = old scaling factor (0.0983) * scaling factor (5.62) * correction factor (0.28639231863102)
 1031,CC_scale_factor_chlorophyll_a,0.0106,
 1031,CC_scale_factor_volume_scatter,3.084E-06,
 1031,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01031__20180628.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01031__20180628.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1031,CC_dark_counts_volume_scatter,49,
 1031,CC_depolarization_ratio,0.039,
 1031,CC_measurement_wavelength,700,
-1031,CC_scale_factor_cdom,0.0673,
+1031,CC_scale_factor_cdom,0.1083210211065361,New cdom scaling factor = old scaling factor (0.0673) * scaling factor (5.62) * correction factor (0.28639231863102)
 1031,CC_scale_factor_chlorophyll_a,0.0108,
 1031,CC_scale_factor_volume_scatter,3.474E-06,
 1031,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01031__20190625.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01031__20190625.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1031,CC_dark_counts_volume_scatter,48,
 1031,CC_depolarization_ratio,0.039,
 1031,CC_measurement_wavelength,700,
-1031,CC_scale_factor_cdom,0.0630,
+1031,CC_scale_factor_cdom,0.1578235873663183,New cdom scaling factor = old scaling factor (0.063) * scaling factor (5.62) * correction factor (0.4457537913526475)
 1031,CC_scale_factor_chlorophyll_a,0.0112,
 1031,CC_scale_factor_volume_scatter,3.433E-06,
 1031,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01031__20200715.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01031__20200715.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1031,CC_dark_counts_volume_scatter,48,
 1031,CC_depolarization_ratio,0.039,
 1031,CC_measurement_wavelength,700,
-1031,CC_scale_factor_cdom,0.0565,
+1031,CC_scale_factor_cdom,0.2407553552737931,New cdom scaling factor = old scaling factor (0.0565) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1031,CC_scale_factor_chlorophyll_a,0.0104,
 1031,CC_scale_factor_volume_scatter,3.139E-06,
 1031,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01031__20220120.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01031__20220120.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1031,CC_dark_counts_volume_scatter,48,
 1031,CC_depolarization_ratio,0.039,Constant
 1031,CC_measurement_wavelength,700,Constant
-1031,CC_scale_factor_cdom,0.0528,
+1031,CC_scale_factor_cdom,0.2249890753709075,New cdom scaling factor = old scaling factor (0.0528) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1031,CC_scale_factor_chlorophyll_a,0.0125,
 1031,CC_scale_factor_volume_scatter,3.507e-06,
 1031,CC_scattering_angle,124,Constant

--- a/calibration/FLORTK/CGINS-FLORTK-01031__20230912.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01031__20230912.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1031,CC_dark_counts_volume_scatter,50.79411765,
 1031,CC_depolarization_ratio,0.039,Constant
 1031,CC_measurement_wavelength,700,Constant
-1031,CC_scale_factor_cdom,9.056E-02,
+1031,CC_scale_factor_cdom,9.056E-02,This calibration not affected by CDOM calibration correction
 1031,CC_scale_factor_chlorophyll_a,1.210E-02,
 1031,CC_scale_factor_volume_scatter,3.024E-06,
 1031,CC_scattering_angle,124,Constant

--- a/calibration/FLORTK/CGINS-FLORTK-01033__20121212.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01033__20121212.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1033,CC_dark_counts_volume_scatter,50,
 1033,CC_depolarization_ratio,0.039,
 1033,CC_measurement_wavelength,700,
-1033,CC_scale_factor_cdom,0.0909,
+1033,CC_scale_factor_cdom,0.1517899592234628,New cdom scaling factor = old scaling factor (0.0909) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1033,CC_scale_factor_chlorophyll_a,0.0121,
 1033,CC_scale_factor_volume_scatter,3.566E-06,
 1033,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01033__20150917.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01033__20150917.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1033,CC_dark_counts_volume_scatter,49.0,
 1033,CC_depolarization_ratio,0.039,
 1033,CC_measurement_wavelength,700.0,
-1033,CC_scale_factor_cdom,0.0927,
+1033,CC_scale_factor_cdom,0.149202951806477,New cdom scaling factor = old scaling factor (0.0927) * scaling factor (5.62) * correction factor (0.28639231863102)
 1033,CC_scale_factor_chlorophyll_a,0.0121,
 1033,CC_scale_factor_volume_scatter,2.979e-06,
 1033,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01100__20130828.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01100__20130828.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1100,CC_dark_counts_volume_scatter,49,
 1100,CC_depolarization_ratio,0.039,
 1100,CC_measurement_wavelength,700,
-1100,CC_scale_factor_cdom,0.09,
+1100,CC_scale_factor_cdom,0.1502870883400622,New cdom scaling factor = old scaling factor (0.09) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1100,CC_scale_factor_chlorophyll_a,0.0121,
 1100,CC_scale_factor_volume_scatter,3.259E-06,
 1100,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01100__20150212.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01100__20150212.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1100,CC_dark_counts_volume_scatter,47.0,
 1100,CC_depolarization_ratio,0.039,
 1100,CC_measurement_wavelength,700.0,
-1100,CC_scale_factor_cdom,0.0808,
+1100,CC_scale_factor_cdom,0.100670785071141,New cdom scaling factor = old scaling factor (0.0808) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1100,CC_scale_factor_chlorophyll_a,0.0121,
 1100,CC_scale_factor_volume_scatter,3.314e-06,
 1100,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01100__20151229.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01100__20151229.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1100,CC_dark_counts_volume_scatter,48.0,
 1100,CC_depolarization_ratio,0.039,
 1100,CC_measurement_wavelength,700.0,
-1100,CC_scale_factor_cdom,0.0753,
+1100,CC_scale_factor_cdom,0.1211972197521868,New cdom scaling factor = old scaling factor (0.0753) * scaling factor (5.62) * correction factor (0.28639231863102)
 1100,CC_scale_factor_chlorophyll_a,0.0121,
 1100,CC_scale_factor_volume_scatter,3.239e-06,
 1100,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01100__20161212.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01100__20161212.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1100,CC_dark_counts_volume_scatter,49,
 1100,CC_depolarization_ratio,0.039,
 1100,CC_measurement_wavelength,700,
-1100,CC_scale_factor_cdom,0.0654,
+1100,CC_scale_factor_cdom,0.1052629239281941,New cdom scaling factor = old scaling factor (0.0654) * scaling factor (5.62) * correction factor (0.28639231863102)
 1100,CC_scale_factor_chlorophyll_a,0.0117,
 1100,CC_scale_factor_volume_scatter,3.19E-06,
 1100,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01100__20180126.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01100__20180126.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1100,CC_dark_counts_volume_scatter,49,
 1100,CC_depolarization_ratio,0.039,
 1100,CC_measurement_wavelength,700,
-1100,CC_scale_factor_cdom,0.0619,
+1100,CC_scale_factor_cdom,0.0996295870207219,New cdom scaling factor = old scaling factor (0.0619) * scaling factor (5.62) * correction factor (0.28639231863102)
 1100,CC_scale_factor_chlorophyll_a,0.0114,
 1100,CC_scale_factor_volume_scatter,3.456E-06,
 1100,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01100__20190111.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01100__20190111.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1100,CC_dark_counts_volume_scatter,48,
 1100,CC_depolarization_ratio,0.039,
 1100,CC_measurement_wavelength,700,
-1100,CC_scale_factor_cdom,0.0537,
+1100,CC_scale_factor_cdom,0.08643148340893,New cdom scaling factor = old scaling factor (0.0537) * scaling factor (5.62) * correction factor (0.28639231863102)
 1100,CC_scale_factor_chlorophyll_a,0.0112,
 1100,CC_scale_factor_volume_scatter,3.459E-06,
 1100,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01100__20191210.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01100__20191210.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1100,CC_dark_counts_volume_scatter,49,
 1100,CC_depolarization_ratio,0.039,
 1100,CC_measurement_wavelength,700,
-1100,CC_scale_factor_cdom,0.0506,
+1100,CC_scale_factor_cdom,0.126759897154535,New cdom scaling factor = old scaling factor (0.0506) * scaling factor (5.62) * correction factor (0.4457537913526475)
 1100,CC_scale_factor_chlorophyll_a,0.0113,
 1100,CC_scale_factor_volume_scatter,3.476E-06,
 1100,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01100__20210108.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01100__20210108.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1100,CC_dark_counts_volume_scatter,48,
 1100,CC_depolarization_ratio,0.039,
 1100,CC_measurement_wavelength,700,
-1100,CC_scale_factor_cdom,0.0907,
+1100,CC_scale_factor_cdom,0.3864869154572219,New cdom scaling factor = old scaling factor (0.0907) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1100,CC_scale_factor_chlorophyll_a,0.0121,
 1100,CC_scale_factor_volume_scatter,3.121E-06,
 1100,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01100__20220120.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01100__20220120.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1100,CC_dark_counts_volume_scatter,47,
 1100,CC_depolarization_ratio,0.039,Constant
 1100,CC_measurement_wavelength,700,Constant
-1100,CC_scale_factor_cdom,0.0844,
+1100,CC_scale_factor_cdom,0.3596416280550114,New cdom scaling factor = old scaling factor (0.0844) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1100,CC_scale_factor_chlorophyll_a,0.0132,
 1100,CC_scale_factor_volume_scatter,3.478E-06,
 1100,CC_scattering_angle,124,Constant

--- a/calibration/FLORTK/CGINS-FLORTK-01100__20230913.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01100__20230913.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1100,CC_dark_counts_volume_scatter,50.575,
 1100,CC_depolarization_ratio,0.039,Constant
 1100,CC_measurement_wavelength,700,Constant
-1100,CC_scale_factor_cdom,9.025E-02,
+1100,CC_scale_factor_cdom,9.025E-02,This calibration not affected by CDOM calibration correction
 1100,CC_scale_factor_chlorophyll_a,1.217E-02,
 1100,CC_scale_factor_volume_scatter,3.026E-06,
 1100,CC_scattering_angle,124,Constant

--- a/calibration/FLORTK/CGINS-FLORTK-01101__20130828.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01101__20130828.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1101,CC_dark_counts_volume_scatter,50.0,
 1101,CC_depolarization_ratio,0.039,
 1101,CC_measurement_wavelength,700.0,
-1101,CC_scale_factor_cdom,0.0902,
+1101,CC_scale_factor_cdom,0.1506210596474846,New cdom scaling factor = old scaling factor (0.0902) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1101,CC_scale_factor_chlorophyll_a,0.0121,
 1101,CC_scale_factor_volume_scatter,2.995e-06,
 1101,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01101__20150219.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01101__20150219.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1101,CC_dark_counts_volume_scatter,49.0,
 1101,CC_depolarization_ratio,0.039,
 1101,CC_measurement_wavelength,700.0,
-1101,CC_scale_factor_cdom,0.0901,
+1101,CC_scale_factor_cdom,0.1122578927587847,New cdom scaling factor = old scaling factor (0.0901) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1101,CC_scale_factor_chlorophyll_a,0.0122,
 1101,CC_scale_factor_volume_scatter,3.078e-06,
 1101,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01101__20151230.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01101__20151230.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1101,CC_dark_counts_volume_scatter,49.0,
 1101,CC_depolarization_ratio,0.039,
 1101,CC_measurement_wavelength,700.0,
-1101,CC_scale_factor_cdom,0.0766,
+1101,CC_scale_factor_cdom,0.1232896020321051,New cdom scaling factor = old scaling factor (0.0766) * scaling factor (5.62) * correction factor (0.28639231863102)
 1101,CC_scale_factor_chlorophyll_a,0.0116,
 1101,CC_scale_factor_volume_scatter,3.067e-06,
 1101,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01101__20161212.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01101__20161212.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1101,CC_dark_counts_volume_scatter,48,
 1101,CC_depolarization_ratio,0.039,
 1101,CC_measurement_wavelength,700,
-1101,CC_scale_factor_cdom,0.0679,
+1101,CC_scale_factor_cdom,0.1092867360049599,New cdom scaling factor = old scaling factor (0.0679) * scaling factor (5.62) * correction factor (0.28639231863102)
 1101,CC_scale_factor_chlorophyll_a,0.0117,
 1101,CC_scale_factor_volume_scatter,3.107E-06,
 1101,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01101__20180126.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01101__20180126.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1101,CC_dark_counts_volume_scatter,49,
 1101,CC_depolarization_ratio,0.039,
 1101,CC_measurement_wavelength,700,
-1101,CC_scale_factor_cdom,0.0631,
+1101,CC_scale_factor_cdom,0.1015610168175696,New cdom scaling factor = old scaling factor (0.0631) * scaling factor (5.62) * correction factor (0.28639231863102)
 1101,CC_scale_factor_chlorophyll_a,0.0117,
 1101,CC_scale_factor_volume_scatter,3.379E-06,
 1101,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01101__20190111.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01101__20190111.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1101,CC_dark_counts_volume_scatter,49,
 1101,CC_depolarization_ratio,0.039,
 1101,CC_measurement_wavelength,700,
-1101,CC_scale_factor_cdom,0.0566,
+1101,CC_scale_factor_cdom,0.0910991054179784,New cdom scaling factor = old scaling factor (0.0566) * scaling factor (5.62) * correction factor (0.28639231863102)
 1101,CC_scale_factor_chlorophyll_a,0.0115,
 1101,CC_scale_factor_volume_scatter,3.378E-06,
 1101,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01101__20191210.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01101__20191210.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1101,CC_dark_counts_volume_scatter,49,
 1101,CC_depolarization_ratio,0.039,
 1101,CC_measurement_wavelength,700,
-1101,CC_scale_factor_cdom,0.0553,
+1101,CC_scale_factor_cdom,0.1385340377993239,New cdom scaling factor = old scaling factor (0.0553) * scaling factor (5.62) * correction factor (0.4457537913526475)
 1101,CC_scale_factor_chlorophyll_a,0.0114,
 1101,CC_scale_factor_volume_scatter,3.476E-06,
 1101,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01101__20210614.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01101__20210614.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1101,CC_dark_counts_volume_scatter,48,
 1101,CC_depolarization_ratio,0.039,
 1101,CC_measurement_wavelength,700,
-1101,CC_scale_factor_cdom,0.0482,
+1101,CC_scale_factor_cdom,0.2053877544105633,New cdom scaling factor = old scaling factor (0.0482) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1101,CC_scale_factor_chlorophyll_a,0.0116,
 1101,CC_scale_factor_volume_scatter,3.488E-06,
 1101,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01101__20230203.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01101__20230203.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1101,CC_dark_counts_volume_scatter,51,
 1101,CC_depolarization_ratio,0.039,
 1101,CC_measurement_wavelength,700,
-1101,CC_scale_factor_cdom,1.015E-01,
+1101,CC_scale_factor_cdom,1.015E-01,This calibration not affected by CDOM calibration correction
 1101,CC_scale_factor_chlorophyll_a,1.248E-02,
 1101,CC_scale_factor_volume_scatter,3.253E-06,
 1101,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01117__20130927.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01117__20130927.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1117,CC_dark_counts_volume_scatter,49,
 1117,CC_depolarization_ratio,0.039,
 1117,CC_measurement_wavelength,700.0,
-1117,CC_scale_factor_cdom,0.0916,
+1117,CC_scale_factor_cdom,0.1529588587994411,New cdom scaling factor = old scaling factor (0.0916) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1117,CC_scale_factor_chlorophyll_a,0.0126,
 1117,CC_scale_factor_volume_scatter,3.084e-06,
 1117,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01117__20150212.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01117__20150212.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1117,CC_dark_counts_volume_scatter,50.0,
 1117,CC_depolarization_ratio,0.039,
 1117,CC_measurement_wavelength,700.0,
-1117,CC_scale_factor_cdom,0.0883,
+1117,CC_scale_factor_cdom,0.1100152267547246,New cdom scaling factor = old scaling factor (0.0883) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1117,CC_scale_factor_chlorophyll_a,0.0121,
 1117,CC_scale_factor_volume_scatter,2.913e-06,
 1117,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01117__20160712.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01117__20160712.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1117,CC_dark_counts_volume_scatter,49.0,
 1117,CC_depolarization_ratio,0.039,
 1117,CC_measurement_wavelength,700.0,
-1117,CC_scale_factor_cdom,0.0713,
+1117,CC_scale_factor_cdom,0.1147591204293615,New cdom scaling factor = old scaling factor (0.0713) * scaling factor (5.62) * correction factor (0.28639231863102)
 1117,CC_scale_factor_chlorophyll_a,0.0118,
 1117,CC_scale_factor_volume_scatter,2.956e-06,
 1117,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01117__20170725.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01117__20170725.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1117,CC_dark_counts_volume_scatter,49,
 1117,CC_depolarization_ratio,0.039,
 1117,CC_measurement_wavelength,700,
-1117,CC_scale_factor_cdom,0.0702,
+1117,CC_scale_factor_cdom,0.1129886431155845,New cdom scaling factor = old scaling factor (0.0702) * scaling factor (5.62) * correction factor (0.28639231863102)
 1117,CC_scale_factor_chlorophyll_a,0.0116,
 1117,CC_scale_factor_volume_scatter,3.159E-06,
 1117,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01117__20180628.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01117__20180628.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1117,CC_dark_counts_volume_scatter,49,
 1117,CC_depolarization_ratio,0.039,
 1117,CC_measurement_wavelength,700,
-1117,CC_scale_factor_cdom,0.0622,
+1117,CC_scale_factor_cdom,0.1001124444699338,New cdom scaling factor = old scaling factor (0.0622) * scaling factor (5.62) * correction factor (0.28639231863102)
 1117,CC_scale_factor_chlorophyll_a,0.0114,
 1117,CC_scale_factor_volume_scatter,3.197E-06,
 1117,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01117__20190625.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01117__20190625.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1117,CC_dark_counts_volume_scatter,49,
 1117,CC_depolarization_ratio,0.039,
 1117,CC_measurement_wavelength,700,
-1117,CC_scale_factor_cdom,0.0553,
+1117,CC_scale_factor_cdom,0.1385340377993239,New cdom scaling factor = old scaling factor (0.0553) * scaling factor (5.62) * correction factor (0.4457537913526475)
 1117,CC_scale_factor_chlorophyll_a,0.0114,
 1117,CC_scale_factor_volume_scatter,3.240E-06,
 1117,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01117__20200728.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01117__20200728.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1117,CC_dark_counts_volume_scatter,49,
 1117,CC_depolarization_ratio,0.039,
 1117,CC_measurement_wavelength,700,
-1117,CC_scale_factor_cdom,0.0503,
+1117,CC_scale_factor_cdom,0.2143361835446335,New cdom scaling factor = old scaling factor (0.0503) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1117,CC_scale_factor_chlorophyll_a,0.0108,
 1117,CC_scale_factor_volume_scatter,3.699E-06,
 1117,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01117__20210622.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01117__20210622.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1117,CC_dark_counts_volume_scatter,48,
 1117,CC_depolarization_ratio,0.039,
 1117,CC_measurement_wavelength,700,
-1117,CC_scale_factor_cdom,0.0498,
+1117,CC_scale_factor_cdom,0.2122056051793787,New cdom scaling factor = old scaling factor (0.0498) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1117,CC_scale_factor_chlorophyll_a,0.0113,
 1117,CC_scale_factor_volume_scatter,3.329E-06,
 1117,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01117__20220713.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01117__20220713.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1117,CC_dark_counts_volume_scatter,50,
 1117,CC_depolarization_ratio,0.039,
 1117,CC_measurement_wavelength,700,
-1117,CC_scale_factor_cdom,8.860E-02,
+1117,CC_scale_factor_cdom,0.3775384863231517,New cdom scaling factor = old scaling factor (0.0886) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1117,CC_scale_factor_chlorophyll_a,1.211E-02,
 1117,CC_scale_factor_volume_scatter,3.258E-06,
 1117,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01117__20240226.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01117__20240226.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1117,CC_dark_counts_volume_scatter,47.9,
 1117,CC_depolarization_ratio,0.039,Constant
 1117,CC_measurement_wavelength,700,Constant
-1117,CC_scale_factor_cdom,9.068E-02,
+1117,CC_scale_factor_cdom,9.068E-02,This calibration not affected by CDOM calibration correction
 1117,CC_scale_factor_chlorophyll_a,1.208E-02,
 1117,CC_scale_factor_volume_scatter,2.996E-06,
 1117,CC_scattering_angle,124,Constant

--- a/calibration/FLORTK/CGINS-FLORTK-01118__20130927.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01118__20130927.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1118,CC_dark_counts_volume_scatter,49,
 1118,CC_depolarization_ratio,0.039,
 1118,CC_measurement_wavelength,700.0,
-1118,CC_scale_factor_cdom,0.0948,
+1118,CC_scale_factor_cdom,0.1583023997181988,New cdom scaling factor = old scaling factor (0.0948) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1118,CC_scale_factor_chlorophyll_a,0.0125,
 1118,CC_scale_factor_volume_scatter,3.077e-06,
 1118,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01118__20150223.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01118__20150223.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1118,CC_dark_counts_volume_scatter,50.0,
 1118,CC_depolarization_ratio,0.039,
 1118,CC_measurement_wavelength,700.0,
-1118,CC_scale_factor_cdom,0.0842,
+1118,CC_scale_factor_cdom,0.1049069319676989,New cdom scaling factor = old scaling factor (0.0842) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1118,CC_scale_factor_chlorophyll_a,0.0123,
 1118,CC_scale_factor_volume_scatter,3.229e-06,
 1118,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01118__20151229.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01118__20151229.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1118,CC_dark_counts_volume_scatter,48.0,
 1118,CC_depolarization_ratio,0.039,
 1118,CC_measurement_wavelength,700.0,
-1118,CC_scale_factor_cdom,0.0771,
+1118,CC_scale_factor_cdom,0.1240943644474582,New cdom scaling factor = old scaling factor (0.0771) * scaling factor (5.62) * correction factor (0.28639231863102)
 1118,CC_scale_factor_chlorophyll_a,0.0122,
 1118,CC_scale_factor_volume_scatter,3.166e-06,
 1118,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01118__20161212.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01118__20161212.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1118,CC_dark_counts_volume_scatter,48,
 1118,CC_depolarization_ratio,0.039,
 1118,CC_measurement_wavelength,700,
-1118,CC_scale_factor_cdom,0.0699,
+1118,CC_scale_factor_cdom,0.1125057856663726,New cdom scaling factor = old scaling factor (0.0699) * scaling factor (5.62) * correction factor (0.28639231863102)
 1118,CC_scale_factor_chlorophyll_a,0.0116,
 1118,CC_scale_factor_volume_scatter,2.996E-06,
 1118,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01118__20180125.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01118__20180125.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1118,CC_dark_counts_volume_scatter,48,
 1118,CC_depolarization_ratio,0.039,
 1118,CC_measurement_wavelength,700,
-1118,CC_scale_factor_cdom,0.0619,
+1118,CC_scale_factor_cdom,0.0996295870207219,New cdom scaling factor = old scaling factor (0.0619) * scaling factor (5.62) * correction factor (0.28639231863102)
 1118,CC_scale_factor_chlorophyll_a,0.0057,
 1118,CC_scale_factor_volume_scatter,3.268E-06,
 1118,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01118__20190111.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01118__20190111.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1118,CC_dark_counts_volume_scatter,49,
 1118,CC_depolarization_ratio,0.039,
 1118,CC_measurement_wavelength,700,
-1118,CC_scale_factor_cdom,0.0555,
+1118,CC_scale_factor_cdom,0.0893286281042014,New cdom scaling factor = old scaling factor (0.0555) * scaling factor (5.62) * correction factor (0.28639231863102)
 1118,CC_scale_factor_chlorophyll_a,0.0108,
 1118,CC_scale_factor_volume_scatter,3.285E-06,
 1118,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01118__20191210.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01118__20191210.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1118,CC_dark_counts_volume_scatter,49,
 1118,CC_depolarization_ratio,0.039,
 1118,CC_measurement_wavelength,700,
-1118,CC_scale_factor_cdom,0.0527,
+1118,CC_scale_factor_cdom,0.132020683400079,New cdom scaling factor = old scaling factor (0.0527) * scaling factor (5.62) * correction factor (0.4457537913526475)
 1118,CC_scale_factor_chlorophyll_a,0.0106,
 1118,CC_scale_factor_volume_scatter,3.341E-06,
 1118,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01118__20210615.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01118__20210615.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1118,CC_dark_counts_volume_scatter,49,
 1118,CC_depolarization_ratio,0.039,
 1118,CC_measurement_wavelength,700,
-1118,CC_scale_factor_cdom,0.0444,
+1118,CC_scale_factor_cdom,0.1891953588346268,New cdom scaling factor = old scaling factor (0.0444) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1118,CC_scale_factor_chlorophyll_a,0.0116,
 1118,CC_scale_factor_volume_scatter,3.503E-06,
 1118,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01118__20230922.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01118__20230922.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1118,CC_dark_counts_volume_scatter,47.525,
 1118,CC_depolarization_ratio,0.039,Constant
 1118,CC_measurement_wavelength,700,Constant
-1118,CC_scale_factor_cdom,9.060E-02,
+1118,CC_scale_factor_cdom,9.060E-02,This calibration not affected by CDOM calibration correction
 1118,CC_scale_factor_chlorophyll_a,1.198E-02,
 1118,CC_scale_factor_volume_scatter,2.957E-06,
 1118,CC_scattering_angle,124,Constant

--- a/calibration/FLORTK/CGINS-FLORTK-01119__20130927.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01119__20130927.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1119,CC_dark_counts_volume_scatter,49.0,
 1119,CC_depolarization_ratio,0.039,
 1119,CC_measurement_wavelength,700.0,
-1119,CC_scale_factor_cdom,0.0904,
+1119,CC_scale_factor_cdom,0.1509550309549069,New cdom scaling factor = old scaling factor (0.0904) * scaling factor (5.62) * correction factor (0.2971274977067264)
 1119,CC_scale_factor_chlorophyll_a,0.0125,
 1119,CC_scale_factor_volume_scatter,3.095e-06,
 1119,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01119__20150212.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01119__20150212.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1119,CC_dark_counts_volume_scatter,48.0,
 1119,CC_depolarization_ratio,0.039,
 1119,CC_measurement_wavelength,700.0,
-1119,CC_scale_factor_cdom,0.0805,
+1119,CC_scale_factor_cdom,0.1002970074037976,New cdom scaling factor = old scaling factor (0.0805) * scaling factor (5.62) * correction factor (0.2216949391123044)
 1119,CC_scale_factor_chlorophyll_a,0.012,
 1119,CC_scale_factor_volume_scatter,3.133e-06,
 1119,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01119__20151230.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01119__20151230.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1119,CC_dark_counts_volume_scatter,48.0,
 1119,CC_depolarization_ratio,0.039,
 1119,CC_measurement_wavelength,700.0,
-1119,CC_scale_factor_cdom,0.072,
+1119,CC_scale_factor_cdom,0.1158857878108559,New cdom scaling factor = old scaling factor (0.072) * scaling factor (5.62) * correction factor (0.28639231863102)
 1119,CC_scale_factor_chlorophyll_a,0.0114,
 1119,CC_scale_factor_volume_scatter,3.069e-06,
 1119,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01119__20161212.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01119__20161212.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1119,CC_dark_counts_volume_scatter,48,
 1119,CC_depolarization_ratio,0.039,
 1119,CC_measurement_wavelength,700,
-1119,CC_scale_factor_cdom,0.0661,
+1119,CC_scale_factor_cdom,0.1063895913096886,New cdom scaling factor = old scaling factor (0.0661) * scaling factor (5.62) * correction factor (0.28639231863102)
 1119,CC_scale_factor_chlorophyll_a,0.0115,
 1119,CC_scale_factor_volume_scatter,3.164E-06,
 1119,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01119__20180126.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01119__20180126.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1119,CC_dark_counts_volume_scatter,49,
 1119,CC_depolarization_ratio,0.039,
 1119,CC_measurement_wavelength,700,
-1119,CC_scale_factor_cdom,0.0624,
+1119,CC_scale_factor_cdom,0.1004343494360751,New cdom scaling factor = old scaling factor (0.0624) * scaling factor (5.62) * correction factor (0.28639231863102)
 1119,CC_scale_factor_chlorophyll_a,0.0057,
 1119,CC_scale_factor_volume_scatter,3.426E-06,
 1119,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01119__20190111.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01119__20190111.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1119,CC_dark_counts_volume_scatter,49,
 1119,CC_depolarization_ratio,0.039,
 1119,CC_measurement_wavelength,700,
-1119,CC_scale_factor_cdom,0.0562,
+1119,CC_scale_factor_cdom,0.0904552954856959,New cdom scaling factor = old scaling factor (0.0562) * scaling factor (5.62) * correction factor (0.28639231863102)
 1119,CC_scale_factor_chlorophyll_a,0.0114,
 1119,CC_scale_factor_volume_scatter,3.410E-06,
 1119,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01119__20191210.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01119__20191210.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1119,CC_dark_counts_volume_scatter,48,
 1119,CC_depolarization_ratio,0.039,
 1119,CC_measurement_wavelength,700,
-1119,CC_scale_factor_cdom,0.0550,
+1119,CC_scale_factor_cdom,0.1377824969071033,New cdom scaling factor = old scaling factor (0.055) * scaling factor (5.62) * correction factor (0.4457537913526475)
 1119,CC_scale_factor_chlorophyll_a,0.0111,
 1119,CC_scale_factor_volume_scatter,3.471E-06,
 1119,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01119__20210615.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01119__20210615.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1119,CC_dark_counts_volume_scatter,48,
 1119,CC_depolarization_ratio,0.039,
 1119,CC_measurement_wavelength,700,
-1119,CC_scale_factor_cdom,0.0465,
+1119,CC_scale_factor_cdom,0.198143787968697,New cdom scaling factor = old scaling factor (0.0465) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1119,CC_scale_factor_chlorophyll_a,0.0121,
 1119,CC_scale_factor_volume_scatter,3.507E-06,
 1119,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01119__20230922.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01119__20230922.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1119,CC_dark_counts_volume_scatter,47.775,
 1119,CC_depolarization_ratio,0.039,Constant
 1119,CC_measurement_wavelength,700,Constant
-1119,CC_scale_factor_cdom,9.050E-02,
+1119,CC_scale_factor_cdom,9.050E-02,This calibration not affected by CDOM calibration correction
 1119,CC_scale_factor_chlorophyll_a,1.209E-02,
 1119,CC_scale_factor_volume_scatter,2.998E-06,
 1119,CC_scattering_angle,124,Constant

--- a/calibration/FLORTK/CGINS-FLORTK-01466__20160627.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01466__20160627.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1466,CC_dark_counts_volume_scatter,43.0,
 1466,CC_depolarization_ratio,0.039,
 1466,CC_measurement_wavelength,700.0,
-1466,CC_scale_factor_cdom,0.0906,
+1466,CC_scale_factor_cdom,0.1458229496619937,New cdom scaling factor = old scaling factor (0.0906) * scaling factor (5.62) * correction factor (0.28639231863102)
 1466,CC_scale_factor_chlorophyll_a,0.0121,
 1466,CC_scale_factor_volume_scatter,3.026e-06,
 1466,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01466__20170725.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01466__20170725.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1466,CC_dark_counts_volume_scatter,50,
 1466,CC_depolarization_ratio,0.039,
 1466,CC_measurement_wavelength,700,
-1466,CC_scale_factor_cdom,0.0941,
+1466,CC_scale_factor_cdom,0.1514562865694659,New cdom scaling factor = old scaling factor (0.0941) * scaling factor (5.62) * correction factor (0.28639231863102)
 1466,CC_scale_factor_chlorophyll_a,0.0115,
 1466,CC_scale_factor_volume_scatter,3.351E-06,
 1466,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01466__20180628.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01466__20180628.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1466,CC_dark_counts_volume_scatter,49,
 1466,CC_depolarization_ratio,0.039,
 1466,CC_measurement_wavelength,700,
-1466,CC_scale_factor_cdom,0.0849,
+1466,CC_scale_factor_cdom,0.1366486581269676,New cdom scaling factor = old scaling factor (0.0849) * scaling factor (5.62) * correction factor (0.28639231863102)
 1466,CC_scale_factor_chlorophyll_a,0.0111,
 1466,CC_scale_factor_volume_scatter,3.404E-06,
 1466,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01466__20190617.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01466__20190617.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1466,CC_dark_counts_volume_scatter,49,
 1466,CC_depolarization_ratio,0.039,
 1466,CC_measurement_wavelength,700,
-1466,CC_scale_factor_cdom,0.0811,
+1466,CC_scale_factor_cdom,0.2031665545302924,New cdom scaling factor = old scaling factor (0.0811) * scaling factor (5.62) * correction factor (0.4457537913526475)
 1466,CC_scale_factor_chlorophyll_a,0.0139,
 1466,CC_scale_factor_volume_scatter,3.387E-06,
 1466,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01466__20200715.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01466__20200715.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1466,CC_dark_counts_volume_scatter,48,
 1466,CC_depolarization_ratio,0.039,
 1466,CC_measurement_wavelength,700,
-1466,CC_scale_factor_cdom,0.0719,
+1466,CC_scale_factor_cdom,0.3063771689236412,New cdom scaling factor = old scaling factor (0.0719) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1466,CC_scale_factor_chlorophyll_a,0.0116,
 1466,CC_scale_factor_volume_scatter,3.039E-06,
 1466,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01466__20220120.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01466__20220120.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1466,CC_dark_counts_volume_scatter,48,
 1466,CC_depolarization_ratio,0.039,Constant
 1466,CC_measurement_wavelength,700,Constant
-1466,CC_scale_factor_cdom,0.0662,
+1466,CC_scale_factor_cdom,0.2820885755597364,New cdom scaling factor = old scaling factor (0.0662) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1466,CC_scale_factor_chlorophyll_a,0.0138,
 1466,CC_scale_factor_volume_scatter,3.446E-06,
 1466,CC_scattering_angle,124,Constant

--- a/calibration/FLORTK/CGINS-FLORTK-01466__20230912.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01466__20230912.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1466,CC_dark_counts_volume_scatter,50.7,
 1466,CC_depolarization_ratio,0.039,Constant
 1466,CC_measurement_wavelength,700,Constant
-1466,CC_scale_factor_cdom,9.022E-02,
+1466,CC_scale_factor_cdom,9.022E-02,This calibration not affected by CDOM calibration correction
 1466,CC_scale_factor_chlorophyll_a,1.308E-02,
 1466,CC_scale_factor_volume_scatter,3.040E-06,
 1466,CC_scattering_angle,124,Constant

--- a/calibration/FLORTK/CGINS-FLORTK-01537__20170125.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01537__20170125.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1537,CC_dark_counts_volume_scatter,48,
 1537,CC_depolarization_ratio,0.039,
 1537,CC_measurement_wavelength,700,
-1537,CC_scale_factor_cdom,0.0909,
+1537,CC_scale_factor_cdom,0.1463058071112056,New cdom scaling factor = old scaling factor (0.0909) * scaling factor (5.62) * correction factor (0.28639231863102)
 1537,CC_scale_factor_chlorophyll_a,0.0121,
 1537,CC_scale_factor_volume_scatter,2.979E-06,
 1537,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01537__20180628.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01537__20180628.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1537,CC_dark_counts_volume_scatter,49,
 1537,CC_depolarization_ratio,0.039,
 1537,CC_measurement_wavelength,700,
-1537,CC_scale_factor_cdom,0.0899,
+1537,CC_scale_factor_cdom,0.1446962822804993,New cdom scaling factor = old scaling factor (0.0899) * scaling factor (5.62) * correction factor (0.28639231863102)
 1537,CC_scale_factor_chlorophyll_a,0.0121,
 1537,CC_scale_factor_volume_scatter,3.539E-06,
 1537,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01537__20190617.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01537__20190617.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1537,CC_dark_counts_volume_scatter,48,
 1537,CC_depolarization_ratio,0.039,
 1537,CC_measurement_wavelength,700,
-1537,CC_scale_factor_cdom,0.0647,
+1537,CC_scale_factor_cdom,0.1620823190889015,New cdom scaling factor = old scaling factor (0.0647) * scaling factor (5.62) * correction factor (0.4457537913526475)
 1537,CC_scale_factor_chlorophyll_a,0.0143,
 1537,CC_scale_factor_volume_scatter,3.609E-06,
 1537,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01537__20200716.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01537__20200716.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1537,CC_dark_counts_volume_scatter,49,
 1537,CC_depolarization_ratio,0.039,
 1537,CC_measurement_wavelength,700,
-1537,CC_scale_factor_cdom,0.0727,
+1537,CC_scale_factor_cdom,0.3097860943080489,New cdom scaling factor = old scaling factor (0.0727) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1537,CC_scale_factor_chlorophyll_a,0.0119,
 1537,CC_scale_factor_volume_scatter,3.617E-06,
 1537,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01537__20210615.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01537__20210615.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1537,CC_dark_counts_volume_scatter,48,
 1537,CC_depolarization_ratio,0.039,
 1537,CC_measurement_wavelength,700,
-1537,CC_scale_factor_cdom,0.0752,
+1537,CC_scale_factor_cdom,0.3204389861343229,New cdom scaling factor = old scaling factor (0.0752) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1537,CC_scale_factor_chlorophyll_a,0.0121,
 1537,CC_scale_factor_volume_scatter,3.613E-06,
 1537,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01537__20230203.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01537__20230203.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1537,CC_dark_counts_volume_scatter,51,
 1537,CC_depolarization_ratio,0.039,
 1537,CC_measurement_wavelength,700,
-1537,CC_scale_factor_cdom,9.587E-02,
+1537,CC_scale_factor_cdom,9.587E-02,This calibration not affected by CDOM calibration correction
 1537,CC_scale_factor_chlorophyll_a,1.207E-02,
 1537,CC_scale_factor_volume_scatter,3.183E-06,
 1537,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01538__20170125.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01538__20170125.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1538,CC_dark_counts_volume_scatter,49,
 1538,CC_depolarization_ratio,0.039,
 1538,CC_measurement_wavelength,700,
-1538,CC_scale_factor_cdom,0.0908,
+1538,CC_scale_factor_cdom,0.146144854628135,New cdom scaling factor = old scaling factor (0.0908) * scaling factor (5.62) * correction factor (0.28639231863102)
 1538,CC_scale_factor_chlorophyll_a,0.0121,
 1538,CC_scale_factor_volume_scatter,2.969E-06,
 1538,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01538__20180628.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01538__20180628.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1538,CC_dark_counts_volume_scatter,49,
 1538,CC_depolarization_ratio,0.039,
 1538,CC_measurement_wavelength,700,
-1538,CC_scale_factor_cdom,0.0861,
+1538,CC_scale_factor_cdom,0.1385800879238152,New cdom scaling factor = old scaling factor (0.0861) * scaling factor (5.62) * correction factor (0.28639231863102)
 1538,CC_scale_factor_chlorophyll_a,0.0119,
 1538,CC_scale_factor_volume_scatter,3.631E-06,
 1538,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01538__20190625.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01538__20190625.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1538,CC_dark_counts_volume_scatter,47,
 1538,CC_depolarization_ratio,0.039,
 1538,CC_measurement_wavelength,700,
-1538,CC_scale_factor_cdom,0.0859,
+1538,CC_scale_factor_cdom,0.2151912088058214,New cdom scaling factor = old scaling factor (0.0859) * scaling factor (5.62) * correction factor (0.4457537913526475)
 1538,CC_scale_factor_chlorophyll_a,0.0122,
 1538,CC_scale_factor_volume_scatter,3.618E-06,
 1538,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01538__20200716.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01538__20200716.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1538,CC_dark_counts_volume_scatter,47,
 1538,CC_depolarization_ratio,0.039,
 1538,CC_measurement_wavelength,700,
-1538,CC_scale_factor_cdom,0.0771,
+1538,CC_scale_factor_cdom,0.3285351839222912,New cdom scaling factor = old scaling factor (0.0771) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1538,CC_scale_factor_chlorophyll_a,0.0120,
 1538,CC_scale_factor_volume_scatter,3.807E-06,
 1538,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01538__20210615.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01538__20210615.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1538,CC_dark_counts_volume_scatter,49,
 1538,CC_depolarization_ratio,0.039,
 1538,CC_measurement_wavelength,700,
-1538,CC_scale_factor_cdom,0.0751,
+1538,CC_scale_factor_cdom,0.3200128704612719,New cdom scaling factor = old scaling factor (0.0751) * scaling factor (5.62) * correction factor (0.7582129413718173)
 1538,CC_scale_factor_chlorophyll_a,0.0121,
 1538,CC_scale_factor_volume_scatter,3.736E-06,
 1538,CC_scattering_angle,124,

--- a/calibration/FLORTK/CGINS-FLORTK-01538__20230203.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01538__20230203.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1538,CC_dark_counts_volume_scatter,52,
 1538,CC_depolarization_ratio,0.039,
 1538,CC_measurement_wavelength,700,
-1538,CC_scale_factor_cdom,9.031E-02,
+1538,CC_scale_factor_cdom,9.031E-02,This calibration not affected by CDOM calibration correction
 1538,CC_scale_factor_chlorophyll_a,1.215E-02,
 1538,CC_scale_factor_volume_scatter,3.247E-06,
 1538,CC_scattering_angle,124,


### PR DESCRIPTION
This is the master PR for the CDOM corrections. I have attached the SeaBird correction table below. 

You will notice that ALL of the FLORT files have been touched - even those that did not need a correction. I added a note to the ones that did not need a correction to state that.

For the ones that did need a new CDOM_scaling_factor, I added a note that includes the old CDOM_scaling_factor along with the two values provided by SeaBird to arrive at the new CDOM_scaling_factor. You should be able to check the following:

1. Identify the calibration file that was changed matches the calibration file in the SeaBird table (attached here)
2. Match the Scaling Factor (SF_cdom) and Correction Factor (CF_cdom) match what is in the SeaBird table
3. Check the new CDOM_scaling_factor matches the old CDOM_scaling_factor * SF_cdom * CF_cdom


[OOI-all-cals-aug-20250601.csv](https://github.com/user-attachments/files/20696182/OOI-all-cals-aug-20250601.csv)
