### PR TITLE
Endurance Array CDOM Scale Factor Corrections

### DIFF
--- a/calibration/FLORTD/CGINS-FLORTD-00995__20121101.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00995__20121101.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 995,CC_dark_counts_volume_scatter,54,
 995,CC_depolarization_ratio,0.039,Constant
 995,CC_measurement_wavelength,700,Constant
-995,CC_scale_factor_cdom,0.0907,
+995,CC_scale_factor_cdom,0.15146,Original scale factor (0.09070) corrected by Sea-Bird with the new value of 0.15146 = 0.09070 * 5.62 * 0.29713
 995,CC_scale_factor_chlorophyll_a,0.0121,
 995,CC_scale_factor_volume_scatter,1.874e-06,
 995,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-00995__20150120.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00995__20150120.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 995,CC_dark_counts_volume_scatter,50,
 995,CC_depolarization_ratio,0.039,Constant
 995,CC_measurement_wavelength,700,Constant
-995,CC_scale_factor_cdom,0.0857,
+995,CC_scale_factor_cdom,0.10678,Original scale factor (0.08570) corrected by Sea-Bird with the new value of 0.10678 = 0.08570 * 5.62 * 0.22169
 995,CC_scale_factor_chlorophyll_a,0.0117,
 995,CC_scale_factor_volume_scatter,1.794e-06,
 995,CC_scattering_angle,124,Constant; updated value

--- a/calibration/FLORTD/CGINS-FLORTD-00995__20151207.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00995__20151207.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 995,CC_dark_counts_volume_scatter,48,
 995,CC_depolarization_ratio,0.039,Constant
 995,CC_measurement_wavelength,700,Constant
-995,CC_scale_factor_cdom,0.0747,
+995,CC_scale_factor_cdom,0.12023,Original scale factor (0.07470) corrected by Sea-Bird with the new value of 0.12023 = 0.07470 * 5.62 * 0.28639
 995,CC_scale_factor_chlorophyll_a,0.0116,
 995,CC_scale_factor_volume_scatter,1.786e-06,
 995,CC_scattering_angle,124,Constant; updated value

--- a/calibration/FLORTD/CGINS-FLORTD-00995__20161129.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00995__20161129.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 995,CC_dark_counts_cdom,46,date in filename comes from dev file
-995,CC_scale_factor_cdom,0.0711,
+995,CC_scale_factor_cdom,0.11444,Original scale factor (0.07110) corrected by Sea-Bird with the new value of 0.11444 = 0.07110 * 5.62 * 0.28639
 995,CC_dark_counts_chlorophyll_a,49,
 995,CC_scale_factor_chlorophyll_a,0.0116,
 995,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-00995__20180110.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00995__20180110.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 995,CC_dark_counts_cdom,46,date in filename comes from dev file
-995,CC_scale_factor_cdom,0.0584,
+995,CC_scale_factor_cdom,0.09400,Original scale factor (0.05840) corrected by Sea-Bird with the new value of 0.09400 = 0.05840 * 5.62 * 0.28639
 995,CC_dark_counts_chlorophyll_a,49,
 995,CC_scale_factor_chlorophyll_a,0.0111,
 995,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-00995__20181211.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00995__20181211.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 995,CC_dark_counts_cdom,50,date in filename comes from dev file
-995,CC_scale_factor_cdom,0.0605,
+995,CC_scale_factor_cdom,0.09738,Original scale factor (0.06050) corrected by Sea-Bird with the new value of 0.09738 = 0.06050 * 5.62 * 0.28639
 995,CC_dark_counts_chlorophyll_a,52,
 995,CC_scale_factor_chlorophyll_a,0.0106,
 995,CC_dark_counts_volume_scatter,48,

--- a/calibration/FLORTD/CGINS-FLORTD-00995__20200108.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00995__20200108.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 995,CC_dark_counts_cdom,52,date in filename comes from dev file
-995,CC_scale_factor_cdom,0.0537,
+995,CC_scale_factor_cdom,0.13453,Original scale factor (0.05370) corrected by Sea-Bird with the new value of 0.13453 = 0.05370 * 5.62 * 0.44575
 995,CC_dark_counts_chlorophyll_a,57,
 995,CC_scale_factor_chlorophyll_a,0.0096,
 995,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-00995__20210524.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00995__20210524.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 995,CC_dark_counts_cdom,48,date in filename comes from dev file
-995,CC_scale_factor_cdom,0.0876,
+995,CC_scale_factor_cdom,0.37328,Original scale factor (0.08760) corrected by Sea-Bird with the new value of 0.37328 = 0.08760 * 5.62 * 0.75821
 995,CC_dark_counts_chlorophyll_a,44,
 995,CC_scale_factor_chlorophyll_a,0.0114,
 995,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-00995__20220518.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00995__20220518.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 995,CC_dark_counts_cdom,49,date in filename comes from dev file
-995,CC_scale_factor_cdom,8.582E-02,
+995,CC_scale_factor_cdom,0.36569,Original scale factor (0.08582) corrected by Sea-Bird with the new value of 0.36569 = 0.08582 * 5.62 * 0.75821
 995,CC_dark_counts_chlorophyll_a,49,
 995,CC_scale_factor_chlorophyll_a,1.092E-02,
 995,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-00996__20121101.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00996__20121101.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 996,CC_dark_counts_volume_scatter,54,
 996,CC_depolarization_ratio,0.039,Constant
 996,CC_measurement_wavelength,700,Constant
-996,CC_scale_factor_cdom,0.0906,
+996,CC_scale_factor_cdom,0.15129,Original scale factor (0.09060) corrected by Sea-Bird with the new value of 0.15129 = 0.09060 * 5.62 * 0.29713
 996,CC_scale_factor_chlorophyll_a,0.0122,
 996,CC_scale_factor_volume_scatter,1.878e-06,
 996,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-00996__20150820.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00996__20150820.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 996,CC_dark_counts_volume_scatter,47,
 996,CC_depolarization_ratio,0.039,Constant
 996,CC_measurement_wavelength,700,Constant
-996,CC_scale_factor_cdom,0.0825,
+996,CC_scale_factor_cdom,0.13279,Original scale factor (0.08250) corrected by Sea-Bird with the new value of 0.13279 = 0.08250 * 5.62 * 0.28639
 996,CC_scale_factor_chlorophyll_a,0.0117,
 996,CC_scale_factor_volume_scatter,1.734e-06,
 996,CC_scattering_angle,124,Constant; updated value

--- a/calibration/FLORTD/CGINS-FLORTD-00996__20160623.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00996__20160623.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 996,CC_dark_counts_volume_scatter,48,
 996,CC_depolarization_ratio,0.039,Constant
 996,CC_measurement_wavelength,700,Constant
-996,CC_scale_factor_cdom,0.0712,
+996,CC_scale_factor_cdom,0.11460,Original scale factor (0.07120) corrected by Sea-Bird with the new value of 0.11460 = 0.07120 * 5.62 * 0.28639
 996,CC_scale_factor_chlorophyll_a,0.0109,
 996,CC_scale_factor_volume_scatter,1.772e-06,
 996,CC_scattering_angle,124,Constant; not 117

--- a/calibration/FLORTD/CGINS-FLORTD-00996__20170615.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00996__20170615.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 996,CC_dark_counts_cdom,45,date in filename comes from factory characterization sheet
-996,CC_scale_factor_cdom,0.0644,
+996,CC_scale_factor_cdom,0.10365,Original scale factor (0.06440) corrected by Sea-Bird with the new value of 0.10365 = 0.06440 * 5.62 * 0.28639
 996,CC_dark_counts_chlorophyll_a,52,
 996,CC_scale_factor_chlorophyll_a,0.0104,
 996,CC_dark_counts_volume_scatter,48,

--- a/calibration/FLORTD/CGINS-FLORTD-00996__20180802.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00996__20180802.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 996,CC_dark_counts_cdom,50,date in filename comes from dev file
-996,CC_scale_factor_cdom,0.0611,
+996,CC_scale_factor_cdom,0.09834,Original scale factor (0.06110) corrected by Sea-Bird with the new value of 0.09834 = 0.06110 * 5.62 * 0.28639
 996,CC_dark_counts_chlorophyll_a,56,
 996,CC_scale_factor_chlorophyll_a,0.0094,
 996,CC_dark_counts_volume_scatter,48,

--- a/calibration/FLORTD/CGINS-FLORTD-00996__20190716.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00996__20190716.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 996,CC_dark_counts_cdom,44,date in filename comes from dev file
-996,CC_scale_factor_cdom,0.0590,
+996,CC_scale_factor_cdom,0.14780,Original scale factor (0.05900) corrected by Sea-Bird with the new value of 0.14780 = 0.05900 * 5.62 * 0.44575
 996,CC_dark_counts_chlorophyll_a,53,
 996,CC_scale_factor_chlorophyll_a,0.0097,
 996,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-00996__20200820.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00996__20200820.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 996,CC_dark_counts_cdom,42,date in filename comes from dev file
-996,CC_scale_factor_cdom,0.0458,
+996,CC_scale_factor_cdom,0.19516,Original scale factor (0.04580) corrected by Sea-Bird with the new value of 0.19516 = 0.04580 * 5.62 * 0.75821
 996,CC_dark_counts_chlorophyll_a,48,
 996,CC_scale_factor_chlorophyll_a,0.0104,
 996,CC_dark_counts_volume_scatter,45,

--- a/calibration/FLORTD/CGINS-FLORTD-00996__20211104.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00996__20211104.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 996,CC_dark_counts_cdom,50,date in filename comes from dev file
-996,CC_scale_factor_cdom,8.930E-02,
+996,CC_scale_factor_cdom,0.38052,Original scale factor (0.08930) corrected by Sea-Bird with the new value of 0.38052 = 0.08930 * 5.62 * 0.75821
 996,CC_dark_counts_chlorophyll_a,56,
 996,CC_scale_factor_chlorophyll_a,1.250E-02,
 996,CC_dark_counts_volume_scatter,49,

--- a/calibration/FLORTD/CGINS-FLORTD-00996__20221107.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-00996__20221107.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 996,CC_dark_counts_cdom,49,date in filename comes from dev file
-996,CC_scale_factor_cdom,9.825E-02,
+996,CC_scale_factor_cdom,0.41866,Original scale factor (0.09825) corrected by Sea-Bird with the new value of 0.41866 = 0.09825 * 5.62 * 0.75821
 996,CC_dark_counts_chlorophyll_a,53,
 996,CC_scale_factor_chlorophyll_a,1.253E-02,
 996,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-01121__20130930.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01121__20130930.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1121,CC_dark_counts_volume_scatter,56,
 1121,CC_depolarization_ratio,0.039,Constant
 1121,CC_measurement_wavelength,700,Constant
-1121,CC_scale_factor_cdom,0.0905,
+1121,CC_scale_factor_cdom,0.15112,Original scale factor (0.09050) corrected by Sea-Bird with the new value of 0.15112 = 0.09050 * 5.62 * 0.29713
 1121,CC_scale_factor_chlorophyll_a,0.012,
 1121,CC_scale_factor_volume_scatter,1.704e-06,
 1121,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01121__20150811.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01121__20150811.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1121,CC_dark_counts_volume_scatter,52,
 1121,CC_depolarization_ratio,0.039,Constant
 1121,CC_measurement_wavelength,700,Constant
-1121,CC_scale_factor_cdom,0.085,
+1121,CC_scale_factor_cdom,0.13681,Original scale factor (0.08500) corrected by Sea-Bird with the new value of 0.13681 = 0.08500 * 5.62 * 0.28639
 1121,CC_scale_factor_chlorophyll_a,0.0117,
 1121,CC_scale_factor_volume_scatter,1.74e-06,
 1121,CC_scattering_angle,124,Constant; updated value

--- a/calibration/FLORTD/CGINS-FLORTD-01121__20160725.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01121__20160725.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1121,CC_dark_counts_volume_scatter,56,ONLY DEPLOYED IN FALL
 1121,CC_depolarization_ratio,0.039,Constant
 1121,CC_measurement_wavelength,700,Constant
-1121,CC_scale_factor_cdom,0.0827,
+1121,CC_scale_factor_cdom,0.13311,Original scale factor (0.08270) corrected by Sea-Bird with the new value of 0.13311 = 0.08270 * 5.62 * 0.28639
 1121,CC_scale_factor_chlorophyll_a,0.0118,
 1121,CC_scale_factor_volume_scatter,1.8e-06,
 1121,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01121__20170630.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01121__20170630.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1121,CC_dark_counts_cdom,46,date in filename comes from factory characterization sheet
-1121,CC_scale_factor_cdom,0.0778,
+1121,CC_scale_factor_cdom,0.12522,Original scale factor (0.07780) corrected by Sea-Bird with the new value of 0.12522 = 0.07780 * 5.62 * 0.28639
 1121,CC_dark_counts_chlorophyll_a,48,
 1121,CC_scale_factor_chlorophyll_a,0.0117,
 1121,CC_dark_counts_volume_scatter,54,

--- a/calibration/FLORTD/CGINS-FLORTD-01121__20180803.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01121__20180803.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1121,CC_dark_counts_cdom,50,date in filename comes from dev file
-1121,CC_scale_factor_cdom,0.0793,
+1121,CC_scale_factor_cdom,0.12764,Original scale factor (0.07930) corrected by Sea-Bird with the new value of 0.12764 = 0.07930 * 5.62 * 0.28639
 1121,CC_dark_counts_chlorophyll_a,52,
 1121,CC_scale_factor_chlorophyll_a,0.0103,
 1121,CC_dark_counts_volume_scatter,57,

--- a/calibration/FLORTD/CGINS-FLORTD-01121__20190713.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01121__20190713.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1121,CC_dark_counts_cdom,46,date in filename comes from dev file
-1121,CC_scale_factor_cdom,0.0664,
+1121,CC_scale_factor_cdom,0.16634,Original scale factor (0.06640) corrected by Sea-Bird with the new value of 0.16634 = 0.06640 * 5.62 * 0.44575
 1121,CC_dark_counts_chlorophyll_a,50,
 1121,CC_scale_factor_chlorophyll_a,0.0115,
 1121,CC_dark_counts_volume_scatter,56,

--- a/calibration/FLORTD/CGINS-FLORTD-01121__20200421.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01121__20200421.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1121,CC_dark_counts_cdom,44,date in filename comes from dev file
-1121,CC_scale_factor_cdom,0.0631,
+1121,CC_scale_factor_cdom,0.26888,Original scale factor (0.06310) corrected by Sea-Bird with the new value of 0.26888 = 0.06310 * 5.62 * 0.75821
 1121,CC_dark_counts_chlorophyll_a,49,
 1121,CC_scale_factor_chlorophyll_a,0.0110,
 1121,CC_dark_counts_volume_scatter,52,

--- a/calibration/FLORTD/CGINS-FLORTD-01121__20211029.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01121__20211029.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1121,CC_dark_counts_cdom,46,date in filename comes from dev file
-1121,CC_scale_factor_cdom,5.430E-02,
+1121,CC_scale_factor_cdom,0.23138,Original scale factor (0.05430) corrected by Sea-Bird with the new value of 0.23138 = 0.05430 * 5.62 * 0.75821
 1121,CC_dark_counts_chlorophyll_a,47,
 1121,CC_scale_factor_chlorophyll_a,1.150E-02,
 1121,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-01121__20221108.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01121__20221108.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1121,CC_dark_counts_cdom,49,date in filename comes from dev file
-1121,CC_scale_factor_cdom,8.994E-02,
+1121,CC_scale_factor_cdom,0.38325,Original scale factor (0.08994) corrected by Sea-Bird with the new value of 0.38325 = 0.08994 * 5.62 * 0.75821
 1121,CC_dark_counts_chlorophyll_a,52,
 1121,CC_scale_factor_chlorophyll_a,1.207E-02,
 1121,CC_dark_counts_volume_scatter,57,

--- a/calibration/FLORTD/CGINS-FLORTD-01123__20130930.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01123__20130930.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1123,CC_dark_counts_volume_scatter,51,
 1123,CC_depolarization_ratio,0.039,Constant
 1123,CC_measurement_wavelength,700,Constant
-1123,CC_scale_factor_cdom,0.098,
+1123,CC_scale_factor_cdom,0.16365,Original scale factor (0.09800) corrected by Sea-Bird with the new value of 0.16365 = 0.09800 * 5.62 * 0.29713
 1123,CC_scale_factor_chlorophyll_a,0.0119,
 1123,CC_scale_factor_volume_scatter,1.727e-06,
 1123,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01123__20151207.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01123__20151207.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1123,CC_dark_counts_volume_scatter,50,
 1123,CC_depolarization_ratio,0.039,Constant
 1123,CC_measurement_wavelength,700,Constant
-1123,CC_scale_factor_cdom,0.0734,
+1123,CC_scale_factor_cdom,0.11814,Original scale factor (0.07340) corrected by Sea-Bird with the new value of 0.11814 = 0.07340 * 5.62 * 0.28639
 1123,CC_scale_factor_chlorophyll_a,0.0115,
 1123,CC_scale_factor_volume_scatter,1.858e-06,
 1123,CC_scattering_angle,124,Constant; not 117

--- a/calibration/FLORTD/CGINS-FLORTD-01123__20161130.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01123__20161130.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1123,CC_dark_counts_cdom,47,date in filename comes from factory characterization sheet
-1123,CC_scale_factor_cdom,0.0677,
+1123,CC_scale_factor_cdom,0.10896,Original scale factor (0.06770) corrected by Sea-Bird with the new value of 0.10896 = 0.06770 * 5.62 * 0.28639
 1123,CC_dark_counts_chlorophyll_a,49,
 1123,CC_scale_factor_chlorophyll_a,0.0116,
 1123,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-01123__20180111.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01123__20180111.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1123,CC_dark_counts_cdom,46,date in filename comes from dev file
-1123,CC_scale_factor_cdom,0.0584,
+1123,CC_scale_factor_cdom,0.09400,Original scale factor (0.05840) corrected by Sea-Bird with the new value of 0.09400 = 0.05840 * 5.62 * 0.28639
 1123,CC_dark_counts_chlorophyll_a,50,
 1123,CC_scale_factor_chlorophyll_a,0.0123,
 1123,CC_dark_counts_volume_scatter,51,

--- a/calibration/FLORTD/CGINS-FLORTD-01123__20181206.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01123__20181206.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1123,CC_dark_counts_cdom,50,date in filename comes from dev file
-1123,CC_scale_factor_cdom,0.0676,
+1123,CC_scale_factor_cdom,0.10880,Original scale factor (0.06760) corrected by Sea-Bird with the new value of 0.10880 = 0.06760 * 5.62 * 0.28639
 1123,CC_dark_counts_chlorophyll_a,52,
 1123,CC_scale_factor_chlorophyll_a,0.0139,
 1123,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-01123__20200108.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01123__20200108.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1123,CC_dark_counts_cdom,53,date in filename comes from dev file
-1123,CC_scale_factor_cdom,0.0662,
+1123,CC_scale_factor_cdom,0.16584,Original scale factor (0.06620) corrected by Sea-Bird with the new value of 0.16584 = 0.06620 * 5.62 * 0.44575
 1123,CC_dark_counts_chlorophyll_a,54,
 1123,CC_scale_factor_chlorophyll_a,0.0111,
 1123,CC_dark_counts_volume_scatter,51,

--- a/calibration/FLORTD/CGINS-FLORTD-01123__20210811.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01123__20210811.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1123,CC_dark_counts_cdom,50,date in filename comes from dev file
-1123,CC_scale_factor_cdom,0.0904,
+1123,CC_scale_factor_cdom,0.38521,Original scale factor (0.09040) corrected by Sea-Bird with the new value of 0.38521 = 0.09040 * 5.62 * 0.75821
 1123,CC_dark_counts_chlorophyll_a,47,
 1123,CC_scale_factor_chlorophyll_a,0.0123,
 1123,CC_dark_counts_volume_scatter,42,

--- a/calibration/FLORTD/CGINS-FLORTD-01123__20220516.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01123__20220516.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1123,CC_dark_counts_cdom,50,date in filename comes from dev file
-1123,CC_scale_factor_cdom,9.283E-02,
+1123,CC_scale_factor_cdom,0.39556,Original scale factor (0.09283) corrected by Sea-Bird with the new value of 0.39556 = 0.09283 * 5.62 * 0.75821
 1123,CC_dark_counts_chlorophyll_a,50,
 1123,CC_scale_factor_chlorophyll_a,1.207E-02,
 1123,CC_dark_counts_volume_scatter,49,

--- a/calibration/FLORTD/CGINS-FLORTD-01151__20140203.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01151__20140203.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1151,CC_dark_counts_volume_scatter,53,
 1151,CC_depolarization_ratio,0.039,Constant
 1151,CC_measurement_wavelength,700,Constant
-1151,CC_scale_factor_cdom,0.0902,
+1151,CC_scale_factor_cdom,0.15062,Original scale factor (0.09020) corrected by Sea-Bird with the new value of 0.15062 = 0.09020 * 5.62 * 0.29713
 1151,CC_scale_factor_chlorophyll_a,0.0073,
 1151,CC_scale_factor_volume_scatter,1.877e-06,
 1151,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01151__20160624.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01151__20160624.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1151,CC_dark_counts_volume_scatter,54,
 1151,CC_depolarization_ratio,0.039,Constant
 1151,CC_measurement_wavelength,700,Constant
-1151,CC_scale_factor_cdom,0.0752,
+1151,CC_scale_factor_cdom,0.12104,Original scale factor (0.07520) corrected by Sea-Bird with the new value of 0.12104 = 0.07520 * 5.62 * 0.28639
 1151,CC_scale_factor_chlorophyll_a,0.0069,
 1151,CC_scale_factor_volume_scatter,2.115e-06,
 1151,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01151__20170619.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01151__20170619.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1151,CC_dark_counts_cdom,42,date in filename comes from factory characterization sheet
-1151,CC_scale_factor_cdom,0.0740,
+1151,CC_scale_factor_cdom,0.11910,Original scale factor (0.07400) corrected by Sea-Bird with the new value of 0.11910 = 0.07400 * 5.62 * 0.28639
 1151,CC_dark_counts_chlorophyll_a,46,
 1151,CC_scale_factor_chlorophyll_a,.0070,
 1151,CC_dark_counts_volume_scatter,54,

--- a/calibration/FLORTD/CGINS-FLORTD-01151__20180803.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01151__20180803.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1151,CC_dark_counts_cdom,48,date in filename comes from dev file
-1151,CC_scale_factor_cdom,0.0773,
+1151,CC_scale_factor_cdom,0.12442,Original scale factor (0.07730) corrected by Sea-Bird with the new value of 0.12442 = 0.07730 * 5.62 * 0.28639
 1151,CC_dark_counts_chlorophyll_a,52,
 1151,CC_scale_factor_chlorophyll_a,.0064,
 1151,CC_dark_counts_volume_scatter,54,

--- a/calibration/FLORTD/CGINS-FLORTD-01151__20190712.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01151__20190712.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1151,CC_dark_counts_cdom,43,date in filename comes from dev file
-1151,CC_scale_factor_cdom,0.0659,
+1151,CC_scale_factor_cdom,0.16509,Original scale factor (0.06590) corrected by Sea-Bird with the new value of 0.16509 = 0.06590 * 5.62 * 0.44575
 1151,CC_dark_counts_chlorophyll_a,49,
 1151,CC_scale_factor_chlorophyll_a,.0075,
 1151,CC_dark_counts_volume_scatter,55,

--- a/calibration/FLORTD/CGINS-FLORTD-01151__20200909.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01151__20200909.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1151,CC_dark_counts_cdom,47,date in filename comes from dev file
-1151,CC_scale_factor_cdom,0.0589,
+1151,CC_scale_factor_cdom,0.25098,Original scale factor (0.05890) corrected by Sea-Bird with the new value of 0.25098 = 0.05890 * 5.62 * 0.75821
 1151,CC_dark_counts_chlorophyll_a,53,
 1151,CC_scale_factor_chlorophyll_a,0.0071,
 1151,CC_dark_counts_volume_scatter,54,

--- a/calibration/FLORTD/CGINS-FLORTD-01151__20211026.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01151__20211026.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1151,CC_dark_counts_cdom,37,date in filename comes from dev file
-1151,CC_scale_factor_cdom,0.0904,
+1151,CC_scale_factor_cdom,0.38521,Original scale factor (0.09040) corrected by Sea-Bird with the new value of 0.38521 = 0.09040 * 5.62 * 0.75821
 1151,CC_dark_counts_chlorophyll_a,59,
 1151,CC_scale_factor_chlorophyll_a,0.0067,
 1151,CC_dark_counts_volume_scatter,55,

--- a/calibration/FLORTD/CGINS-FLORTD-01151__20221108.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01151__20221108.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1151,CC_dark_counts_cdom,37,date in filename comes from dev file
-1151,CC_scale_factor_cdom,9.095E-02,
+1151,CC_scale_factor_cdom,0.38755,Original scale factor (0.09095) corrected by Sea-Bird with the new value of 0.38755 = 0.09095 * 5.62 * 0.75821
 1151,CC_dark_counts_chlorophyll_a,54,
 1151,CC_scale_factor_chlorophyll_a,7.441E-03,
 1151,CC_dark_counts_volume_scatter,57,

--- a/calibration/FLORTD/CGINS-FLORTD-01152__20131230.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01152__20131230.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1152,CC_dark_counts_volume_scatter,50,
 1152,CC_depolarization_ratio,0.039,Constant
 1152,CC_measurement_wavelength,700,Constant
-1152,CC_scale_factor_cdom,0.0905,
+1152,CC_scale_factor_cdom,0.15112,Original scale factor (0.09050) corrected by Sea-Bird with the new value of 0.15112 = 0.09050 * 5.62 * 0.29713
 1152,CC_scale_factor_chlorophyll_a,0.0073,
 1152,CC_scale_factor_volume_scatter,1.833e-06,
 1152,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01152__20151207.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01152__20151207.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1152,CC_dark_counts_volume_scatter,50,
 1152,CC_depolarization_ratio,0.039,Constant
 1152,CC_measurement_wavelength,700,Constant
-1152,CC_scale_factor_cdom,0.0811,
+1152,CC_scale_factor_cdom,0.13053,Original scale factor (0.08110) corrected by Sea-Bird with the new value of 0.13053 = 0.08110 * 5.62 * 0.28639
 1152,CC_scale_factor_chlorophyll_a,0.007,
 1152,CC_scale_factor_volume_scatter,1.935e-06,
 1152,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01152__20161129.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01152__20161129.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1152,CC_dark_counts_cdom,47,date in filename comes from factory characterization sheet
-1152,CC_scale_factor_cdom,0.0782,
+1152,CC_scale_factor_cdom,0.12586,Original scale factor (0.07820) corrected by Sea-Bird with the new value of 0.12586 = 0.07820 * 5.62 * 0.28639
 1152,CC_dark_counts_chlorophyll_a,47,
 1152,CC_scale_factor_chlorophyll_a,0.0069,
 1152,CC_dark_counts_volume_scatter,52,

--- a/calibration/FLORTD/CGINS-FLORTD-01152__20180110.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01152__20180110.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1152,CC_dark_counts_cdom,46,date in filename comes from dev file
-1152,CC_scale_factor_cdom,0.0743,
+1152,CC_scale_factor_cdom,0.11959,Original scale factor (0.07430) corrected by Sea-Bird with the new value of 0.11959 = 0.07430 * 5.62 * 0.28639
 1152,CC_dark_counts_chlorophyll_a,46,
 1152,CC_scale_factor_chlorophyll_a,.0072,
 1152,CC_dark_counts_volume_scatter,54,

--- a/calibration/FLORTD/CGINS-FLORTD-01152__20181206.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01152__20181206.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1152,CC_dark_counts_cdom,50,date in filename comes from dev file
-1152,CC_scale_factor_cdom,.0734,
+1152,CC_scale_factor_cdom,0.11814,Original scale factor (0.07340) corrected by Sea-Bird with the new value of 0.11814 = 0.07340 * 5.62 * 0.28639
 1152,CC_dark_counts_chlorophyll_a,50,
 1152,CC_scale_factor_chlorophyll_a,.0077,
 1152,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-01152__20200108.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01152__20200108.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1152,CC_dark_counts_cdom,48,date in filename comes from dev file
-1152,CC_scale_factor_cdom,.0646,
+1152,CC_scale_factor_cdom,0.16183,Original scale factor (0.06460) corrected by Sea-Bird with the new value of 0.16183 = 0.06460 * 5.62 * 0.44575
 1152,CC_dark_counts_chlorophyll_a,53,
 1152,CC_scale_factor_chlorophyll_a,.0062,
 1152,CC_dark_counts_volume_scatter,53,

--- a/calibration/FLORTD/CGINS-FLORTD-01152__20210609.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01152__20210609.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1152,CC_dark_counts_cdom,46,date in filename comes from dev file
-1152,CC_scale_factor_cdom,0.0899,
+1152,CC_scale_factor_cdom,0.38308,Original scale factor (0.08990) corrected by Sea-Bird with the new value of 0.38308 = 0.08990 * 5.62 * 0.75821
 1152,CC_dark_counts_chlorophyll_a,44,
 1152,CC_scale_factor_chlorophyll_a,0.0073,
 1152,CC_dark_counts_volume_scatter,48,

--- a/calibration/FLORTD/CGINS-FLORTD-01152__20220524.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01152__20220524.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1152,CC_dark_counts_cdom,49,date in filename comes from dev file
-1152,CC_scale_factor_cdom,7.969E-02,
+1152,CC_scale_factor_cdom,0.33957,Original scale factor (0.07969) corrected by Sea-Bird with the new value of 0.33957 = 0.07969 * 5.62 * 0.75821
 1152,CC_dark_counts_chlorophyll_a,47,
 1152,CC_scale_factor_chlorophyll_a,7.190E-03,
 1152,CC_dark_counts_volume_scatter,49,

--- a/calibration/FLORTD/CGINS-FLORTD-01153__20131230.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01153__20131230.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1153,CC_dark_counts_volume_scatter,49,
 1153,CC_depolarization_ratio,0.039,Constant
 1153,CC_measurement_wavelength,700,Constant
-1153,CC_scale_factor_cdom,0.0896,
+1153,CC_scale_factor_cdom,0.14962,Original scale factor (0.08960) corrected by Sea-Bird with the new value of 0.14962 = 0.08960 * 5.62 * 0.29713
 1153,CC_scale_factor_chlorophyll_a,0.0073,
 1153,CC_scale_factor_volume_scatter,1.837e-06,
 1153,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01153__20150820.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01153__20150820.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1153,CC_dark_counts_volume_scatter,50,
 1153,CC_depolarization_ratio,0.039,Constant
 1153,CC_measurement_wavelength,700,Constant
-1153,CC_scale_factor_cdom,0.0886,
+1153,CC_scale_factor_cdom,0.14260,Original scale factor (0.08860) corrected by Sea-Bird with the new value of 0.14260 = 0.08860 * 5.62 * 0.28639
 1153,CC_scale_factor_chlorophyll_a,0.0073,
 1153,CC_scale_factor_volume_scatter,1.831e-06,
 1153,CC_scattering_angle,124,Constant; updated value

--- a/calibration/FLORTD/CGINS-FLORTD-01153__20160627.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01153__20160627.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1153,CC_dark_counts_volume_scatter,50,
 1153,CC_depolarization_ratio,0.039,Constant
 1153,CC_measurement_wavelength,700,Constant
-1153,CC_scale_factor_cdom,0.0786,
+1153,CC_scale_factor_cdom,0.12651,Original scale factor (0.07860) corrected by Sea-Bird with the new value of 0.12651 = 0.07860 * 5.62 * 0.28639
 1153,CC_scale_factor_chlorophyll_a,0.0069,
 1153,CC_scale_factor_volume_scatter,1.86e-06,
 1153,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01153__20170602.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01153__20170602.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1153,CC_dark_counts_cdom,45,date in filename comes from factory characterization sheet
-1153,CC_scale_factor_cdom,0.0750,
+1153,CC_scale_factor_cdom,0.12071,Original scale factor (0.07500) corrected by Sea-Bird with the new value of 0.12071 = 0.07500 * 5.62 * 0.28639
 1153,CC_dark_counts_chlorophyll_a,46,
 1153,CC_scale_factor_chlorophyll_a,0.0070,
 1153,CC_dark_counts_volume_scatter,46,

--- a/calibration/FLORTD/CGINS-FLORTD-01153__20180803.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01153__20180803.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1153,CC_dark_counts_cdom,50,date in filename comes from dev file
-1153,CC_scale_factor_cdom,0.0720,
+1153,CC_scale_factor_cdom,0.11589,Original scale factor (0.07200) corrected by Sea-Bird with the new value of 0.11589 = 0.07200 * 5.62 * 0.28639
 1153,CC_dark_counts_chlorophyll_a,50,
 1153,CC_scale_factor_chlorophyll_a,0.0062,
 1153,CC_dark_counts_volume_scatter,48,

--- a/calibration/FLORTD/CGINS-FLORTD-01153__20190716.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01153__20190716.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1153,CC_dark_counts_cdom,46,date in filename comes from dev file
-1153,CC_scale_factor_cdom,0.0659,
+1153,CC_scale_factor_cdom,0.16509,Original scale factor (0.06590) corrected by Sea-Bird with the new value of 0.16509 = 0.06590 * 5.62 * 0.44575
 1153,CC_dark_counts_chlorophyll_a,52,
 1153,CC_scale_factor_chlorophyll_a,0.0074,
 1153,CC_dark_counts_volume_scatter,49,

--- a/calibration/FLORTD/CGINS-FLORTD-01153__20200909.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01153__20200909.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1153,CC_dark_counts_cdom,47,date in filename comes from dev file
-1153,CC_scale_factor_cdom,0.0590,
+1153,CC_scale_factor_cdom,0.25141,Original scale factor (0.05900) corrected by Sea-Bird with the new value of 0.25141 = 0.05900 * 5.62 * 0.75821
 1153,CC_dark_counts_chlorophyll_a,52,
 1153,CC_scale_factor_chlorophyll_a,0.0067,
 1153,CC_dark_counts_volume_scatter,48,

--- a/calibration/FLORTD/CGINS-FLORTD-01153__20211108.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01153__20211108.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1153,CC_dark_counts_cdom,46,date in filename comes from dev file
-1153,CC_scale_factor_cdom,9.000E-02,
+1153,CC_scale_factor_cdom,0.38350,Original scale factor (0.09000) corrected by Sea-Bird with the new value of 0.38350 = 0.09000 * 5.62 * 0.75821
 1153,CC_dark_counts_chlorophyll_a,46,
 1153,CC_scale_factor_chlorophyll_a,7.200E-03,
 1153,CC_dark_counts_volume_scatter,45,

--- a/calibration/FLORTD/CGINS-FLORTD-01153__20221107.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01153__20221107.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1153,CC_dark_counts_cdom,49,date in filename comes from dev file
-1153,CC_scale_factor_cdom,9.129E-02,
+1153,CC_scale_factor_cdom,0.38900,Original scale factor (0.09129) corrected by Sea-Bird with the new value of 0.38900 = 0.09129 * 5.62 * 0.75821
 1153,CC_dark_counts_chlorophyll_a,50,
 1153,CC_scale_factor_chlorophyll_a,7.351E-03,
 1153,CC_dark_counts_volume_scatter,46,

--- a/calibration/FLORTD/CGINS-FLORTD-01154__20131230.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01154__20131230.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1154,CC_dark_counts_cdom,44,date in filename comes from factory characterization sheet
-1154,CC_scale_factor_cdom,0.0904,
+1154,CC_scale_factor_cdom,0.15096,Original scale factor (0.09040) corrected by Sea-Bird with the new value of 0.15096 = 0.09040 * 5.62 * 0.29713
 1154,CC_dark_counts_chlorophyll_a,45,
 1154,CC_scale_factor_chlorophyll_a,.0073,
 1154,CC_dark_counts_volume_scatter,47,

--- a/calibration/FLORTD/CGINS-FLORTD-01154__20150811.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01154__20150811.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1154,CC_dark_counts_volume_scatter,47,
 1154,CC_depolarization_ratio,0.039,Constant
 1154,CC_measurement_wavelength,700,Constant
-1154,CC_scale_factor_cdom,0.0882,
+1154,CC_scale_factor_cdom,0.14196,Original scale factor (0.08820) corrected by Sea-Bird with the new value of 0.14196 = 0.08820 * 5.62 * 0.28639
 1154,CC_scale_factor_chlorophyll_a,0.0073,
 1154,CC_scale_factor_volume_scatter,1.847e-06,
 1154,CC_scattering_angle,124,Constant; updated value

--- a/calibration/FLORTD/CGINS-FLORTD-01154__20160725.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01154__20160725.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1154,CC_dark_counts_volume_scatter,48,ONLY DEPLOYED IN FALL
 1154,CC_depolarization_ratio,0.039,Constant
 1154,CC_measurement_wavelength,700,Constant
-1154,CC_scale_factor_cdom,0.0813,
+1154,CC_scale_factor_cdom,0.13085,Original scale factor (0.08130) corrected by Sea-Bird with the new value of 0.13085 = 0.08130 * 5.62 * 0.28639
 1154,CC_scale_factor_chlorophyll_a,0.007,
 1154,CC_scale_factor_volume_scatter,1.862e-06,
 1154,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01154__20170621.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01154__20170621.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1154,CC_dark_counts_cdom,42,date in filename comes from factory characterization sheet
-1154,CC_scale_factor_cdom,0.0781,
+1154,CC_scale_factor_cdom,0.12570,Original scale factor (0.07810) corrected by Sea-Bird with the new value of 0.12570 = 0.07810 * 5.62 * 0.28639
 1154,CC_dark_counts_chlorophyll_a,46,
 1154,CC_scale_factor_chlorophyll_a,.0070,
 1154,CC_dark_counts_volume_scatter,54,

--- a/calibration/FLORTD/CGINS-FLORTD-01154__20180802.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01154__20180802.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1154,CC_dark_counts_cdom,50,date in filename comes from dev file
-1154,CC_scale_factor_cdom,0.0846,
+1154,CC_scale_factor_cdom,0.13617,Original scale factor (0.08460) corrected by Sea-Bird with the new value of 0.13617 = 0.08460 * 5.62 * 0.28639
 1154,CC_dark_counts_chlorophyll_a,50,
 1154,CC_scale_factor_chlorophyll_a,.0066,
 1154,CC_dark_counts_volume_scatter,65,

--- a/calibration/FLORTD/CGINS-FLORTD-01154__20190713.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01154__20190713.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1154,CC_dark_counts_cdom,47,date in filename comes from dev file
-1154,CC_scale_factor_cdom,0.0906,
+1154,CC_scale_factor_cdom,0.22697,Original scale factor (0.09060) corrected by Sea-Bird with the new value of 0.22697 = 0.09060 * 5.62 * 0.44575
 1154,CC_dark_counts_chlorophyll_a,48,
 1154,CC_scale_factor_chlorophyll_a,.0068,
 1154,CC_dark_counts_volume_scatter,49,

--- a/calibration/FLORTD/CGINS-FLORTD-01154__20200820.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01154__20200820.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1154,CC_dark_counts_cdom,47,date in filename comes from dev file
-1154,CC_scale_factor_cdom,0.0835,
+1154,CC_scale_factor_cdom,0.35581,Original scale factor (0.08350) corrected by Sea-Bird with the new value of 0.35581 = 0.08350 * 5.62 * 0.75821
 1154,CC_dark_counts_chlorophyll_a,50,
 1154,CC_scale_factor_chlorophyll_a,.0123,
 1154,CC_dark_counts_volume_scatter,45,

--- a/calibration/FLORTD/CGINS-FLORTD-01154__20211101.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01154__20211101.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1154,CC_dark_counts_cdom,48,date in filename comes from dev file
-1154,CC_scale_factor_cdom,0.0731,
+1154,CC_scale_factor_cdom,0.31149,Original scale factor (0.07310) corrected by Sea-Bird with the new value of 0.31149 = 0.07310 * 5.62 * 0.75821
 1154,CC_dark_counts_chlorophyll_a,50,
 1154,CC_scale_factor_chlorophyll_a,.0127,
 1154,CC_dark_counts_volume_scatter,47,

--- a/calibration/FLORTD/CGINS-FLORTD-01154__20221107.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01154__20221107.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1154,CC_dark_counts_cdom,48,date in filename comes from dev file
-1154,CC_scale_factor_cdom,8.451E-02,
+1154,CC_scale_factor_cdom,0.36011,Original scale factor (0.08451) corrected by Sea-Bird with the new value of 0.36011 = 0.08451 * 5.62 * 0.75821
 1154,CC_dark_counts_chlorophyll_a,50,
 1154,CC_scale_factor_chlorophyll_a,1.169E-02,
 1154,CC_dark_counts_volume_scatter,49,

--- a/calibration/FLORTD/CGINS-FLORTD-01155__20131230.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01155__20131230.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1155,CC_dark_counts_volume_scatter,50,
 1155,CC_depolarization_ratio,0.039,Constant
 1155,CC_measurement_wavelength,700,Constant
-1155,CC_scale_factor_cdom,0.0903,
+1155,CC_scale_factor_cdom,0.15079,Original scale factor (0.09030) corrected by Sea-Bird with the new value of 0.15079 = 0.09030 * 5.62 * 0.29713
 1155,CC_scale_factor_chlorophyll_a,0.0073,
 1155,CC_scale_factor_volume_scatter,1.84e-06,
 1155,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01155__20151204.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01155__20151204.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1155,CC_dark_counts_volume_scatter,50,
 1155,CC_depolarization_ratio,0.039,Constant
 1155,CC_measurement_wavelength,700,Constant
-1155,CC_scale_factor_cdom,0.0877,
+1155,CC_scale_factor_cdom,0.14116,Original scale factor (0.08770) corrected by Sea-Bird with the new value of 0.14116 = 0.08770 * 5.62 * 0.28639
 1155,CC_scale_factor_chlorophyll_a,0.0071,
 1155,CC_scale_factor_volume_scatter,1.913e-06,
 1155,CC_scattering_angle,124,Constant; not 117

--- a/calibration/FLORTD/CGINS-FLORTD-01155__20161130.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01155__20161130.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1155,CC_dark_counts_cdom,47,date in filename comes from factory characterization sheet
-1155,CC_scale_factor_cdom,0.0777,
+1155,CC_scale_factor_cdom,0.12506,Original scale factor (0.07770) corrected by Sea-Bird with the new value of 0.12506 = 0.07770 * 5.62 * 0.28639
 1155,CC_dark_counts_chlorophyll_a,49,
 1155,CC_scale_factor_chlorophyll_a,0.0071,
 1155,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-01155__20180110.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01155__20180110.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1155,CC_dark_counts_cdom,47,date in filename comes from dev file
-1155,CC_scale_factor_cdom,0.0744,
+1155,CC_scale_factor_cdom,0.11975,Original scale factor (0.07440) corrected by Sea-Bird with the new value of 0.11975 = 0.07440 * 5.62 * 0.28639
 1155,CC_dark_counts_chlorophyll_a,50,
 1155,CC_scale_factor_chlorophyll_a,.0071,
 1155,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-01155__20181206.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01155__20181206.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1155,CC_dark_counts_cdom,50,date in filename comes from dev file
-1155,CC_scale_factor_cdom,.0761,
+1155,CC_scale_factor_cdom,0.12248,Original scale factor (0.07610) corrected by Sea-Bird with the new value of 0.12248 = 0.07610 * 5.62 * 0.28639
 1155,CC_dark_counts_chlorophyll_a,53,
 1155,CC_scale_factor_chlorophyll_a,.0089,
 1155,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-01155__20200108.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01155__20200108.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1155,CC_dark_counts_cdom,48,date in filename comes from dev file
-1155,CC_scale_factor_cdom,.0729,
+1155,CC_scale_factor_cdom,0.18262,Original scale factor (0.07290) corrected by Sea-Bird with the new value of 0.18262 = 0.07290 * 5.62 * 0.44575
 1155,CC_dark_counts_chlorophyll_a,50,
 1155,CC_scale_factor_chlorophyll_a,.0065,
 1155,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-01155__20210610.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01155__20210610.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1155,CC_dark_counts_cdom,48,date in filename comes from dev file
-1155,CC_scale_factor_cdom,0.0901,
+1155,CC_scale_factor_cdom,0.38393,Original scale factor (0.09010) corrected by Sea-Bird with the new value of 0.38393 = 0.09010 * 5.62 * 0.75821
 1155,CC_dark_counts_chlorophyll_a,51,
 1155,CC_scale_factor_chlorophyll_a,0.0074,
 1155,CC_dark_counts_volume_scatter,48,

--- a/calibration/FLORTD/CGINS-FLORTD-01155__20220517.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01155__20220517.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1155,CC_dark_counts_cdom,49,date in filename comes from dev file
-1155,CC_scale_factor_cdom,8.212E-02,
+1155,CC_scale_factor_cdom,0.34993,Original scale factor (0.08212) corrected by Sea-Bird with the new value of 0.34993 = 0.08212 * 5.62 * 0.75821
 1155,CC_dark_counts_chlorophyll_a,51,
 1155,CC_scale_factor_chlorophyll_a,7.564E-03,
 1155,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-01197__20140625.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01197__20140625.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1197,CC_dark_counts_volume_scatter,50,
 1197,CC_depolarization_ratio,0.039,Constant
 1197,CC_measurement_wavelength,700,Constant
-1197,CC_scale_factor_cdom,0.0904,
+1197,CC_scale_factor_cdom,0.11263,Original scale factor (0.09040) corrected by Sea-Bird with the new value of 0.11263 = 0.09040 * 5.62 * 0.22169
 1197,CC_scale_factor_chlorophyll_a,0.0121,
 1197,CC_scale_factor_volume_scatter,1.835e-06,
 1197,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01197__20151204.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01197__20151204.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1197,CC_dark_counts_volume_scatter,49,
 1197,CC_depolarization_ratio,0.039,Constant
 1197,CC_measurement_wavelength,700,Constant
-1197,CC_scale_factor_cdom,0.0823,
+1197,CC_scale_factor_cdom,0.13246,Original scale factor (0.08230) corrected by Sea-Bird with the new value of 0.13246 = 0.08230 * 5.62 * 0.28639
 1197,CC_scale_factor_chlorophyll_a,0.0121,
 1197,CC_scale_factor_volume_scatter,1.915e-06,
 1197,CC_scattering_angle,124,Constant; updated value

--- a/calibration/FLORTD/CGINS-FLORTD-01197__20161130.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01197__20161130.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1197,CC_dark_counts_cdom,46,date in filename comes from factory characterization sheet
-1197,CC_scale_factor_cdom,0.0732,
+1197,CC_scale_factor_cdom,0.11782,Original scale factor (0.07320) corrected by Sea-Bird with the new value of 0.11782 = 0.07320 * 5.62 * 0.28639
 1197,CC_dark_counts_chlorophyll_a,52,
 1197,CC_scale_factor_chlorophyll_a,0.0118,
 1197,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-01197__20180116.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01197__20180116.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1197,CC_dark_counts_cdom,47,date in filename comes from dev file
-1197,CC_scale_factor_cdom,0.0678,
+1197,CC_scale_factor_cdom,0.10913,Original scale factor (0.06780) corrected by Sea-Bird with the new value of 0.10913 = 0.06780 * 5.62 * 0.28639
 1197,CC_dark_counts_chlorophyll_a,53,
 1197,CC_scale_factor_chlorophyll_a,.0122,
 1197,CC_dark_counts_volume_scatter,51,

--- a/calibration/FLORTD/CGINS-FLORTD-01197__20181206.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01197__20181206.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1197,CC_dark_counts_cdom,50,date in filename comes from dev file
-1197,CC_scale_factor_cdom,0.0652,
+1197,CC_scale_factor_cdom,0.10494,Original scale factor (0.06520) corrected by Sea-Bird with the new value of 0.10494 = 0.06520 * 5.62 * 0.28639
 1197,CC_dark_counts_chlorophyll_a,57,
 1197,CC_scale_factor_chlorophyll_a,.0114,
 1197,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-01197__20200108.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01197__20200108.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1197,CC_dark_counts_cdom,55,date in filename comes from pdf file
-1197,CC_scale_factor_cdom,0.0603,
+1197,CC_scale_factor_cdom,0.15106,Original scale factor (0.06030) corrected by Sea-Bird with the new value of 0.15106 = 0.06030 * 5.62 * 0.44575
 1197,CC_dark_counts_chlorophyll_a,56,
 1197,CC_scale_factor_chlorophyll_a,.0105,
 1197,CC_dark_counts_volume_scatter,55,

--- a/calibration/FLORTD/CGINS-FLORTD-01197__20210611.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01197__20210611.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1197,CC_dark_counts_cdom,48,date in filename comes from dev file
-1197,CC_scale_factor_cdom,0.0903,
+1197,CC_scale_factor_cdom,0.38478,Original scale factor (0.09030) corrected by Sea-Bird with the new value of 0.38478 = 0.09030 * 5.62 * 0.75821
 1197,CC_dark_counts_chlorophyll_a,49,
 1197,CC_scale_factor_chlorophyll_a,.0121,
 1197,CC_dark_counts_volume_scatter,47,

--- a/calibration/FLORTD/CGINS-FLORTD-01197__20220527.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01197__20220527.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1197,CC_dark_counts_cdom,47,date in filename comes from dev file
-1197,CC_scale_factor_cdom,8.623E-02,
+1197,CC_scale_factor_cdom,0.36744,Original scale factor (0.08623) corrected by Sea-Bird with the new value of 0.36744 = 0.08623 * 5.62 * 0.75821
 1197,CC_dark_counts_chlorophyll_a,49,
 1197,CC_scale_factor_chlorophyll_a,1.191E-02,
 1197,CC_dark_counts_volume_scatter,41,

--- a/calibration/FLORTD/CGINS-FLORTD-01290__20150528.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01290__20150528.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1290,CC_dark_counts_volume_scatter,49,
 1290,CC_depolarization_ratio,0.039,Constant
 1290,CC_measurement_wavelength,700,Constant
-1290,CC_scale_factor_cdom,0.0903,
+1290,CC_scale_factor_cdom,0.11251,Original scale factor (0.09030) corrected by Sea-Bird with the new value of 0.11251 = 0.09030 * 5.62 * 0.22169
 1290,CC_scale_factor_chlorophyll_a,0.0121,
 1290,CC_scale_factor_volume_scatter,1.818e-06,
 1290,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01290__20161130.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01290__20161130.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1290,CC_dark_counts_cdom,47,date in filename comes from factory characterization sheet
-1290,CC_scale_factor_cdom,0.0868,
+1290,CC_scale_factor_cdom,0.13971,Original scale factor (0.08680) corrected by Sea-Bird with the new value of 0.13971 = 0.08680 * 5.62 * 0.28639
 1290,CC_dark_counts_chlorophyll_a,49,
 1290,CC_scale_factor_chlorophyll_a,0.013,
 1290,CC_dark_counts_volume_scatter,51,

--- a/calibration/FLORTD/CGINS-FLORTD-01290__20180117.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01290__20180117.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1290,CC_dark_counts_cdom,46,date in filename comes from dev file
-1290,CC_scale_factor_cdom,0.0820,
+1290,CC_scale_factor_cdom,0.13198,Original scale factor (0.08200) corrected by Sea-Bird with the new value of 0.13198 = 0.08200 * 5.62 * 0.28639
 1290,CC_dark_counts_chlorophyll_a,49,
 1290,CC_scale_factor_chlorophyll_a,0.0127,
 1290,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-01290__20181210.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01290__20181210.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1290,CC_dark_counts_cdom,50,date in filename comes from dev file
-1290,CC_scale_factor_cdom,0.0808,
+1290,CC_scale_factor_cdom,0.13005,Original scale factor (0.08080) corrected by Sea-Bird with the new value of 0.13005 = 0.08080 * 5.62 * 0.28639
 1290,CC_dark_counts_chlorophyll_a,53,
 1290,CC_scale_factor_chlorophyll_a,0.0126,
 1290,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-01290__20200109.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01290__20200109.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1290,CC_dark_counts_cdom,46,date in filename comes from dev file
-1290,CC_scale_factor_cdom,0.0776,
+1290,CC_scale_factor_cdom,0.19440,Original scale factor (0.07760) corrected by Sea-Bird with the new value of 0.19440 = 0.07760 * 5.62 * 0.44575
 1290,CC_dark_counts_chlorophyll_a,50,
 1290,CC_scale_factor_chlorophyll_a,0.0115,
 1290,CC_dark_counts_volume_scatter,51,

--- a/calibration/FLORTD/CGINS-FLORTD-01290__20210611.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01290__20210611.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1290,CC_dark_counts_cdom,47,date in filename comes from dev file
-1290,CC_scale_factor_cdom,0.0901,
+1290,CC_scale_factor_cdom,0.38393,Original scale factor (0.09010) corrected by Sea-Bird with the new value of 0.38393 = 0.09010 * 5.62 * 0.75821
 1290,CC_dark_counts_chlorophyll_a,45,
 1290,CC_scale_factor_chlorophyll_a,0.0121,
 1290,CC_dark_counts_volume_scatter,48,

--- a/calibration/FLORTD/CGINS-FLORTD-01290__20220524.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01290__20220524.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1290,CC_dark_counts_cdom,49,date in filename comes from dev file
-1290,CC_scale_factor_cdom,7.620E-02,
+1290,CC_scale_factor_cdom,0.32470,Original scale factor (0.07620) corrected by Sea-Bird with the new value of 0.32470 = 0.07620 * 5.62 * 0.75821
 1290,CC_dark_counts_chlorophyll_a,46,
 1290,CC_scale_factor_chlorophyll_a,1.205E-02,
 1290,CC_dark_counts_volume_scatter,49,

--- a/calibration/FLORTD/CGINS-FLORTD-01291__20150529.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01291__20150529.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1291,CC_dark_counts_volume_scatter,48,
 1291,CC_depolarization_ratio,0.039,Constant
 1291,CC_measurement_wavelength,700,Constant
-1291,CC_scale_factor_cdom,0.0907,
+1291,CC_scale_factor_cdom,0.11301,Original scale factor (0.09070) corrected by Sea-Bird with the new value of 0.11301 = 0.09070 * 5.62 * 0.22169
 1291,CC_scale_factor_chlorophyll_a,0.0121,
 1291,CC_scale_factor_volume_scatter,1.839e-06,
 1291,CC_scattering_angle,124,Constant; not 117

--- a/calibration/FLORTD/CGINS-FLORTD-01291__20160622.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01291__20160622.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1291,CC_dark_counts_volume_scatter,50,
 1291,CC_depolarization_ratio,0.039,Constant
 1291,CC_measurement_wavelength,700,Constant
-1291,CC_scale_factor_cdom,0.0912,
+1291,CC_scale_factor_cdom,0.14679,Original scale factor (0.09120) corrected by Sea-Bird with the new value of 0.14679 = 0.09120 * 5.62 * 0.28639
 1291,CC_scale_factor_chlorophyll_a,0.0124,
 1291,CC_scale_factor_volume_scatter,1.91e-06,
 1291,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01291__20170616.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01291__20170616.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1291,CC_dark_counts_cdom,46,date in filename comes from factory characterization sheet
-1291,CC_scale_factor_cdom,0.0835,
+1291,CC_scale_factor_cdom,0.13440,Original scale factor (0.08350) corrected by Sea-Bird with the new value of 0.13440 = 0.08350 * 5.62 * 0.28639
 1291,CC_dark_counts_chlorophyll_a,49,
 1291,CC_scale_factor_chlorophyll_a,.0119,
 1291,CC_dark_counts_volume_scatter,48,

--- a/calibration/FLORTD/CGINS-FLORTD-01291__20180803.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01291__20180803.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1291,CC_dark_counts_cdom,50,date in filename comes from dev file
-1291,CC_scale_factor_cdom,0.0899,
+1291,CC_scale_factor_cdom,0.14470,Original scale factor (0.08990) corrected by Sea-Bird with the new value of 0.14470 = 0.08990 * 5.62 * 0.28639
 1291,CC_dark_counts_chlorophyll_a,53,
 1291,CC_scale_factor_chlorophyll_a,.0110,
 1291,CC_dark_counts_volume_scatter,49,

--- a/calibration/FLORTD/CGINS-FLORTD-01291__20190709.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01291__20190709.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1291,CC_dark_counts_cdom,43,date in filename comes from dev file
-1291,CC_scale_factor_cdom,0.0795,
+1291,CC_scale_factor_cdom,0.19916,Original scale factor (0.07950) corrected by Sea-Bird with the new value of 0.19916 = 0.07950 * 5.62 * 0.44575
 1291,CC_dark_counts_chlorophyll_a,50,
 1291,CC_scale_factor_chlorophyll_a,.0120,
 1291,CC_dark_counts_volume_scatter,48,

--- a/calibration/FLORTD/CGINS-FLORTD-01291__20200820.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01291__20200820.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1291,CC_dark_counts_cdom,44,date in filename comes from dev file
-1291,CC_scale_factor_cdom,0.0745,
+1291,CC_scale_factor_cdom,0.31746,Original scale factor (0.07450) corrected by Sea-Bird with the new value of 0.31746 = 0.07450 * 5.62 * 0.75821
 1291,CC_dark_counts_chlorophyll_a,45,
 1291,CC_scale_factor_chlorophyll_a,.0126,
 1291,CC_dark_counts_volume_scatter,45,

--- a/calibration/FLORTD/CGINS-FLORTD-01291__20211027.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01291__20211027.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1291,CC_dark_counts_cdom,46,date in filename comes from dev file
-1291,CC_scale_factor_cdom,5.890E-02,
+1291,CC_scale_factor_cdom,0.25098,Original scale factor (0.05890) corrected by Sea-Bird with the new value of 0.25098 = 0.05890 * 5.62 * 0.75821
 1291,CC_dark_counts_chlorophyll_a,49,
 1291,CC_scale_factor_chlorophyll_a,1.230E-02,
 1291,CC_dark_counts_volume_scatter,48,

--- a/calibration/FLORTD/CGINS-FLORTD-01291__20221108.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01291__20221108.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1291,CC_dark_counts_cdom,49,date in filename comes from dev file
-1291,CC_scale_factor_cdom,9.011E-02,
+1291,CC_scale_factor_cdom,0.38397,Original scale factor (0.09011) corrected by Sea-Bird with the new value of 0.38397 = 0.09011 * 5.62 * 0.75821
 1291,CC_dark_counts_chlorophyll_a,52,
 1291,CC_scale_factor_chlorophyll_a,1.351E-02,
 1291,CC_dark_counts_volume_scatter,51,

--- a/calibration/FLORTD/CGINS-FLORTD-01302__20150514.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01302__20150514.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1302,CC_dark_counts_volume_scatter,54,
 1302,CC_depolarization_ratio,0.039,Constant
 1302,CC_measurement_wavelength,700,Constant
-1302,CC_scale_factor_cdom,0.0907,
+1302,CC_scale_factor_cdom,0.11301,Original scale factor (0.09070) corrected by Sea-Bird with the new value of 0.11301 = 0.09070 * 5.62 * 0.22169
 1302,CC_scale_factor_chlorophyll_a,0.0121,
 1302,CC_scale_factor_volume_scatter,1.819e-06,
 1302,CC_scattering_angle,124,Constant; not 117

--- a/calibration/FLORTD/CGINS-FLORTD-01302__20160719.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01302__20160719.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1302,CC_dark_counts_volume_scatter,51,
 1302,CC_depolarization_ratio,0.039,Constant
 1302,CC_measurement_wavelength,700,Constant
-1302,CC_scale_factor_cdom,0.0882,
+1302,CC_scale_factor_cdom,0.14196,Original scale factor (0.08820) corrected by Sea-Bird with the new value of 0.14196 = 0.08820 * 5.62 * 0.28639
 1302,CC_scale_factor_chlorophyll_a,0.012,
 1302,CC_scale_factor_volume_scatter,1.926e-06,
 1302,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01302__20170602.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01302__20170602.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1302,CC_dark_counts_cdom,49,date in filename comes from factory characterization sheet
-1302,CC_scale_factor_cdom,0.0733,
+1302,CC_scale_factor_cdom,0.11798,Original scale factor (0.07330) corrected by Sea-Bird with the new value of 0.11798 = 0.07330 * 5.62 * 0.28639
 1302,CC_dark_counts_chlorophyll_a,46,
 1302,CC_scale_factor_chlorophyll_a,.0116,
 1302,CC_dark_counts_volume_scatter,51,

--- a/calibration/FLORTD/CGINS-FLORTD-01302__20180803.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01302__20180803.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1302,CC_dark_counts_cdom,48,date in filename comes from dev file
-1302,CC_scale_factor_cdom,0.0709,
+1302,CC_scale_factor_cdom,0.11412,Original scale factor (0.07090) corrected by Sea-Bird with the new value of 0.11412 = 0.07090 * 5.62 * 0.28639
 1302,CC_dark_counts_chlorophyll_a,56,
 1302,CC_scale_factor_chlorophyll_a,.0099,
 1302,CC_dark_counts_volume_scatter,53,

--- a/calibration/FLORTD/CGINS-FLORTD-01302__20190715.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01302__20190715.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1302,CC_dark_counts_cdom,45,date in filename comes from dev file
-1302,CC_scale_factor_cdom,0.0604,
+1302,CC_scale_factor_cdom,0.15131,Original scale factor (0.06040) corrected by Sea-Bird with the new value of 0.15131 = 0.06040 * 5.62 * 0.44575
 1302,CC_dark_counts_chlorophyll_a,54,
 1302,CC_scale_factor_chlorophyll_a,.0120,
 1302,CC_dark_counts_volume_scatter,54,

--- a/calibration/FLORTD/CGINS-FLORTD-01302__20200421.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01302__20200421.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1302,CC_dark_counts_cdom,43,date in filename comes from dev file
-1302,CC_scale_factor_cdom,0.0602,
+1302,CC_scale_factor_cdom,0.25652,Original scale factor (0.06020) corrected by Sea-Bird with the new value of 0.25652 = 0.06020 * 5.62 * 0.75821
 1302,CC_dark_counts_chlorophyll_a,49,
 1302,CC_scale_factor_chlorophyll_a,.0106,
 1302,CC_dark_counts_volume_scatter,52,

--- a/calibration/FLORTD/CGINS-FLORTD-01302__20211102.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01302__20211102.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1302,CC_dark_counts_cdom,43,date in filename comes from dev file
-1302,CC_scale_factor_cdom,4.730E-02,
+1302,CC_scale_factor_cdom,0.20155,Original scale factor (0.04730) corrected by Sea-Bird with the new value of 0.20155 = 0.04730 * 5.62 * 0.75821
 1302,CC_dark_counts_chlorophyll_a,41,
 1302,CC_scale_factor_chlorophyll_a,1.040E-02,
 1302,CC_dark_counts_volume_scatter,51,

--- a/calibration/FLORTD/CGINS-FLORTD-01302__20221108.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01302__20221108.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1302,CC_dark_counts_cdom,48,date in filename comes from dev file
-1302,CC_scale_factor_cdom,9.222E-02,
+1302,CC_scale_factor_cdom,0.39296,Original scale factor (0.09222) corrected by Sea-Bird with the new value of 0.39296 = 0.09222 * 5.62 * 0.75821
 1302,CC_dark_counts_chlorophyll_a,54,
 1302,CC_scale_factor_chlorophyll_a,1.217E-02,
 1302,CC_dark_counts_volume_scatter,54,

--- a/calibration/FLORTD/CGINS-FLORTD-01303__20150529.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01303__20150529.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1303,CC_dark_counts_volume_scatter,50,
 1303,CC_depolarization_ratio,0.039,Constant
 1303,CC_measurement_wavelength,700,Constant
-1303,CC_scale_factor_cdom,0.0906,
+1303,CC_scale_factor_cdom,0.11288,Original scale factor (0.09060) corrected by Sea-Bird with the new value of 0.11288 = 0.09060 * 5.62 * 0.22169
 1303,CC_scale_factor_chlorophyll_a,0.0121,
 1303,CC_scale_factor_volume_scatter,1.85e-06,
 1303,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01303__20160719.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01303__20160719.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1303,CC_dark_counts_volume_scatter,52,
 1303,CC_depolarization_ratio,0.039,Constant
 1303,CC_measurement_wavelength,700,Constant
-1303,CC_scale_factor_cdom,0.0863,
+1303,CC_scale_factor_cdom,0.13890,Original scale factor (0.08630) corrected by Sea-Bird with the new value of 0.13890 = 0.08630 * 5.62 * 0.28639
 1303,CC_scale_factor_chlorophyll_a,0.0124,
 1303,CC_scale_factor_volume_scatter,1.934e-06,
 1303,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01303__20170602.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01303__20170602.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1303,CC_dark_counts_cdom,46,date in filename comes from factory characterization sheet
-1303,CC_scale_factor_cdom,0.0747,
+1303,CC_scale_factor_cdom,0.12023,Original scale factor (0.07470) corrected by Sea-Bird with the new value of 0.12023 = 0.07470 * 5.62 * 0.28639
 1303,CC_dark_counts_chlorophyll_a,50,
 1303,CC_scale_factor_chlorophyll_a,.0118,
 1303,CC_dark_counts_volume_scatter,51,

--- a/calibration/FLORTD/CGINS-FLORTD-01303__20180802.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01303__20180802.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1303,CC_dark_counts_cdom,50,date in filename comes from dev file
-1303,CC_scale_factor_cdom,0.0809,
+1303,CC_scale_factor_cdom,0.13021,Original scale factor (0.08090) corrected by Sea-Bird with the new value of 0.13021 = 0.08090 * 5.62 * 0.28639
 1303,CC_dark_counts_chlorophyll_a,56,
 1303,CC_scale_factor_chlorophyll_a,.0105,
 1303,CC_dark_counts_volume_scatter,83,

--- a/calibration/FLORTD/CGINS-FLORTD-01303__20190709.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01303__20190709.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1303,CC_dark_counts_cdom,45,date in filename comes from dev file
-1303,CC_scale_factor_cdom,0.0681,
+1303,CC_scale_factor_cdom,0.17060,Original scale factor (0.06810) corrected by Sea-Bird with the new value of 0.17060 = 0.06810 * 5.62 * 0.44575
 1303,CC_dark_counts_chlorophyll_a,52,
 1303,CC_scale_factor_chlorophyll_a,.0117,
 1303,CC_dark_counts_volume_scatter,51,

--- a/calibration/FLORTD/CGINS-FLORTD-01303__20201029.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01303__20201029.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1303,CC_dark_counts_cdom,47,date in filename comes from dev file
-1303,CC_scale_factor_cdom,0.0637,
+1303,CC_scale_factor_cdom,0.27144,Original scale factor (0.06370) corrected by Sea-Bird with the new value of 0.27144 = 0.06370 * 5.62 * 0.75821
 1303,CC_dark_counts_chlorophyll_a,53,
 1303,CC_scale_factor_chlorophyll_a,0.0114,
 1303,CC_dark_counts_volume_scatter,52,

--- a/calibration/FLORTD/CGINS-FLORTD-01303__20211102.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01303__20211102.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1303,CC_dark_counts_cdom,46,date in filename comes from dev file
-1303,CC_scale_factor_cdom,5.610E-02,
+1303,CC_scale_factor_cdom,0.23905,Original scale factor (0.05610) corrected by Sea-Bird with the new value of 0.23905 = 0.05610 * 5.62 * 0.75821
 1303,CC_dark_counts_chlorophyll_a,50,
 1303,CC_scale_factor_chlorophyll_a,1.180E-02,
 1303,CC_dark_counts_volume_scatter,55,

--- a/calibration/FLORTD/CGINS-FLORTD-01303__20221107.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01303__20221107.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1303,CC_dark_counts_cdom,49,date in filename comes from dev file
-1303,CC_scale_factor_cdom,9.163E-02,
+1303,CC_scale_factor_cdom,0.39045,Original scale factor (0.09163) corrected by Sea-Bird with the new value of 0.39045 = 0.09163 * 5.62 * 0.75821
 1303,CC_dark_counts_chlorophyll_a,56,
 1303,CC_scale_factor_chlorophyll_a,1.120E-02,
 1303,CC_dark_counts_volume_scatter,60,

--- a/calibration/FLORTD/CGINS-FLORTD-01487__20160808.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01487__20160808.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1487,CC_dark_counts_volume_scatter,51,
 1487,CC_depolarization_ratio,0.039,Constant
 1487,CC_measurement_wavelength,700,Constant
-1487,CC_scale_factor_cdom,0.0909,
+1487,CC_scale_factor_cdom,0.14631,Original scale factor (0.09090) corrected by Sea-Bird with the new value of 0.14631 = 0.09090 * 5.62 * 0.28639
 1487,CC_scale_factor_chlorophyll_a,0.0121,
 1487,CC_scale_factor_volume_scatter,1.805e-06,
 1487,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01487__20180117.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01487__20180117.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1487,CC_dark_counts_cdom,47,date in filename comes from dev file
-1487,CC_scale_factor_cdom,0.0821,
+1487,CC_scale_factor_cdom,0.13214,Original scale factor (0.08210) corrected by Sea-Bird with the new value of 0.13214 = 0.08210 * 5.62 * 0.28639
 1487,CC_dark_counts_chlorophyll_a,53,
 1487,CC_scale_factor_chlorophyll_a,.0121,
 1487,CC_dark_counts_volume_scatter,53,

--- a/calibration/FLORTD/CGINS-FLORTD-01487__20181211.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01487__20181211.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1487,CC_dark_counts_cdom,50,date in filename comes from dev file
-1487,CC_scale_factor_cdom,0.0911,
+1487,CC_scale_factor_cdom,0.14663,Original scale factor (0.09110) corrected by Sea-Bird with the new value of 0.14663 = 0.09110 * 5.62 * 0.28639
 1487,CC_dark_counts_chlorophyll_a,56,
 1487,CC_scale_factor_chlorophyll_a,.0133,
 1487,CC_dark_counts_volume_scatter,53,

--- a/calibration/FLORTD/CGINS-FLORTD-01487__20200109.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01487__20200109.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1487,CC_dark_counts_cdom,46,date in filename comes from dev file
-1487,CC_scale_factor_cdom,0.0855,
+1487,CC_scale_factor_cdom,0.21419,Original scale factor (0.08550) corrected by Sea-Bird with the new value of 0.21419 = 0.08550 * 5.62 * 0.44575
 1487,CC_dark_counts_chlorophyll_a,53,
 1487,CC_scale_factor_chlorophyll_a,.0101,
 1487,CC_dark_counts_volume_scatter,53,

--- a/calibration/FLORTD/CGINS-FLORTD-01487__20210609.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01487__20210609.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1487,CC_dark_counts_cdom,47,date in filename comes from dev file
-1487,CC_scale_factor_cdom,0.0907,
+1487,CC_scale_factor_cdom,0.38649,Original scale factor (0.09070) corrected by Sea-Bird with the new value of 0.38649 = 0.09070 * 5.62 * 0.75821
 1487,CC_dark_counts_chlorophyll_a,49,
 1487,CC_scale_factor_chlorophyll_a,0.0122,
 1487,CC_dark_counts_volume_scatter,49,

--- a/calibration/FLORTD/CGINS-FLORTD-01487__20220517.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01487__20220517.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1487,CC_dark_counts_cdom,49,date in filename comes from dev file
-1487,CC_scale_factor_cdom,8.212E-02,
+1487,CC_scale_factor_cdom,0.34993,Original scale factor (0.08212) corrected by Sea-Bird with the new value of 0.34993 = 0.08212 * 5.62 * 0.75821
 1487,CC_dark_counts_chlorophyll_a,49,
 1487,CC_scale_factor_chlorophyll_a,1.153E-02,
 1487,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-01488__20160808.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01488__20160808.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1488,CC_dark_counts_cdom,46,date in filename comes from factory characterization sheet
-1488,CC_scale_factor_cdom,0.0908,
+1488,CC_scale_factor_cdom,0.14614,Original scale factor (0.09080) corrected by Sea-Bird with the new value of 0.14614 = 0.09080 * 5.62 * 0.28639
 1488,CC_dark_counts_chlorophyll_a,48,
 1488,CC_scale_factor_chlorophyll_a,0.0121,
 1488,CC_dark_counts_volume_scatter,52,

--- a/calibration/FLORTD/CGINS-FLORTD-01488__20180118.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01488__20180118.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1488,CC_dark_counts_cdom,48,date in filename comes from dev file
-1488,CC_scale_factor_cdom,0.0918,
+1488,CC_scale_factor_cdom,0.14775,Original scale factor (0.09180) corrected by Sea-Bird with the new value of 0.14775 = 0.09180 * 5.62 * 0.28639
 1488,CC_dark_counts_chlorophyll_a,53,
 1488,CC_scale_factor_chlorophyll_a,.0123,
 1488,CC_dark_counts_volume_scatter,53,

--- a/calibration/FLORTD/CGINS-FLORTD-01488__20181211.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01488__20181211.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1488,CC_dark_counts_cdom,50,date in filename comes from dev file
-1488,CC_scale_factor_cdom,0.0915,
+1488,CC_scale_factor_cdom,0.14727,Original scale factor (0.09150) corrected by Sea-Bird with the new value of 0.14727 = 0.09150 * 5.62 * 0.28639
 1488,CC_dark_counts_chlorophyll_a,56,
 1488,CC_scale_factor_chlorophyll_a,.0119,
 1488,CC_dark_counts_volume_scatter,51,

--- a/calibration/FLORTD/CGINS-FLORTD-01488__20200109.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01488__20200109.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1488,CC_dark_counts_cdom,47,date in filename comes from dev file
-1488,CC_scale_factor_cdom,0.0903,
+1488,CC_scale_factor_cdom,0.22621,Original scale factor (0.09030) corrected by Sea-Bird with the new value of 0.22621 = 0.09030 * 5.62 * 0.44575
 1488,CC_dark_counts_chlorophyll_a,49,
 1488,CC_scale_factor_chlorophyll_a,.0106,
 1488,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTD/CGINS-FLORTD-01488__20210611.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01488__20210611.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1488,CC_dark_counts_cdom,48,date in filename comes from dev file
-1488,CC_scale_factor_cdom,0.0902,
+1488,CC_scale_factor_cdom,0.38436,Original scale factor (0.09020) corrected by Sea-Bird with the new value of 0.38436 = 0.09020 * 5.62 * 0.75821
 1488,CC_dark_counts_chlorophyll_a,50,
 1488,CC_scale_factor_chlorophyll_a,.0121,
 1488,CC_dark_counts_volume_scatter,48,

--- a/calibration/FLORTD/CGINS-FLORTD-01488__20220518.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01488__20220518.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1488,CC_dark_counts_cdom,49,date in filename comes from dev file
-1488,CC_scale_factor_cdom,8.330E-02,
+1488,CC_scale_factor_cdom,0.35495,Original scale factor (0.08330) corrected by Sea-Bird with the new value of 0.35495 = 0.08330 * 5.62 * 0.75821
 1488,CC_dark_counts_chlorophyll_a,50,
 1488,CC_scale_factor_chlorophyll_a,1.178E-02,
 1488,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01084__20130620.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01084__20130620.csv
@@ -5,7 +5,7 @@ BBFL2W-1084,CC_dark_counts_chlorophyll_a,58,Measured signal output of fluormeter
 BBFL2W-1084,CC_dark_counts_volume_scatter,55,Measured signal output of fluormeter in clean water with black tape over the detector [counts]
 BBFL2W-1084,CC_depolarization_ratio,0.039,Depolarization ratio [unitless].
 BBFL2W-1084,CC_measurement_wavelength,700,Optical backscatter measurement wavelength [nm].
-BBFL2W-1084,CC_scale_factor_cdom,0.0906,Multiplier [ppb counts^-1]
+BBFL2W-1084,CC_scale_factor_cdom,0.15129,Original scale factor (0.09060) corrected by Sea-Bird with the new value of 0.15129 = 0.09060 * 5.62 * 0.29713
 BBFL2W-1084,CC_scale_factor_chlorophyll_a,0.0122,Multiplier [ug L^-1 counts^-1]
 BBFL2W-1084,CC_scale_factor_volume_scatter,3.08e-06,Multiplier [m^-1 sr^-1 counts^-1]
 BBFL2W-1084,CC_scattering_angle,124,Optical backscatter scattering angle [degrees].

--- a/calibration/FLORTJ/CGINS-FLORTJ-01084__20160504.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01084__20160504.csv
@@ -5,7 +5,7 @@ BBFL2W-1084,CC_dark_counts_chlorophyll_a,43,Measured signal output of fluoromete
 BBFL2W-1084,CC_dark_counts_volume_scatter,51,Measured signal output of scatterometer in clean water with black tape over the detector [counts]
 BBFL2W-1084,CC_depolarization_ratio,0.039,Depolarization ratio [unitless].
 BBFL2W-1084,CC_measurement_wavelength,700,Optical backscatter measurement wavelength [nm].
-BBFL2W-1084,CC_scale_factor_cdom,0.0864,Multiplier [ppb counts^-1]
+BBFL2W-1084,CC_scale_factor_cdom,0.13906,Original scale factor (0.08640) corrected by Sea-Bird with the new value of 0.13906 = 0.08640 * 5.62 * 0.28639
 BBFL2W-1084,CC_scale_factor_chlorophyll_a,0.0112,Multiplier [ug L^-1 counts^-1]
 BBFL2W-1084,CC_scale_factor_volume_scatter,3.396e-06,Multiplier [m^-1 sr^-1 counts^-1]
 BBFL2W-1084,CC_scattering_angle,124,Optical backscatter scattering angle [degrees].

--- a/calibration/FLORTJ/CGINS-FLORTJ-01084__20161115.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01084__20161115.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1084,CC_dark_counts_cdom,44,date in filename comes from factory characterization sheet
-BBFL2W-1084,CC_scale_factor_cdom,0.096,
+BBFL2W-1084,CC_scale_factor_cdom,0.15451,Original scale factor (0.09600) corrected by Sea-Bird with the new value of 0.15451 = 0.09600 * 5.62 * 0.28639
 BBFL2W-1084,CC_dark_counts_chlorophyll_a,47,
 BBFL2W-1084,CC_scale_factor_chlorophyll_a,0.0112,
 BBFL2W-1084,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01084__20180810.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01084__20180810.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1084,CC_dark_counts_cdom,49,date in filename comes from dev file
-BBFL2W-1084,CC_scale_factor_cdom,0.1040,
+BBFL2W-1084,CC_scale_factor_cdom,0.16739,Original scale factor (0.10400) corrected by Sea-Bird with the new value of 0.16739 = 0.10400 * 5.62 * 0.28639
 BBFL2W-1084,CC_dark_counts_chlorophyll_a,56,
 BBFL2W-1084,CC_scale_factor_chlorophyll_a,0.0117,
 BBFL2W-1084,CC_dark_counts_volume_scatter,54,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01084__20200114.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01084__20200114.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1084,CC_dark_counts_cdom,42,date in filename comes from dev file
-BBFL2W-1084,CC_scale_factor_cdom,0.0892,
+BBFL2W-1084,CC_scale_factor_cdom,0.22346,Original scale factor (0.08920) corrected by Sea-Bird with the new value of 0.22346 = 0.08920 * 5.62 * 0.44575
 BBFL2W-1084,CC_dark_counts_chlorophyll_a,46,
 BBFL2W-1084,CC_scale_factor_chlorophyll_a,0.0109,
 BBFL2W-1084,CC_dark_counts_volume_scatter,49,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01084__20220524.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01084__20220524.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1084,CC_dark_counts_cdom,50,date in filename comes from dev file
-BBFL2W-1084,CC_scale_factor_cdom,8.847E-02,
+BBFL2W-1084,CC_scale_factor_cdom,0.37698,Original scale factor (0.08847) corrected by Sea-Bird with the new value of 0.37698 = 0.08847 * 5.62 * 0.75821
 BBFL2W-1084,CC_dark_counts_chlorophyll_a,52,
 BBFL2W-1084,CC_scale_factor_chlorophyll_a,1.061E-02,
 BBFL2W-1084,CC_dark_counts_volume_scatter,54,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01084__20221216.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01084__20221216.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1084,CC_dark_counts_cdom,48,date in filename comes from dev file
-BBFL2W-1084,CC_scale_factor_cdom,1.037E-01,
+BBFL2W-1084,CC_scale_factor_cdom,0.44188,Original scale factor (0.10370) corrected by Sea-Bird with the new value of 0.44188 = 0.10370 * 5.62 * 0.75821
 BBFL2W-1084,CC_dark_counts_chlorophyll_a,51,
 BBFL2W-1084,CC_scale_factor_chlorophyll_a,1.186E-02,
 BBFL2W-1084,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01156__20160617.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01156__20160617.csv
@@ -5,7 +5,7 @@ BBFL2W-1156,CC_dark_counts_chlorophyll_a,51,Measured signal output of fluoromete
 BBFL2W-1156,CC_dark_counts_volume_scatter,52,Measured signal output of scatterometer in clean water with black tape over the detector [counts]
 BBFL2W-1156,CC_depolarization_ratio,0.039,Depolarization ratio [unitless].
 BBFL2W-1156,CC_measurement_wavelength,700,Optical backscatter measurement wavelength [nm].
-BBFL2W-1156,CC_scale_factor_cdom,0.0772,Multiplier [ppb counts^-1]
+BBFL2W-1156,CC_scale_factor_cdom,0.12426,Original scale factor (0.07720) corrected by Sea-Bird with the new value of 0.12426 = 0.07720 * 5.62 * 0.28639
 BBFL2W-1156,CC_scale_factor_chlorophyll_a,0.0118,Multiplier [ug L^-1 counts^-1]
 BBFL2W-1156,CC_scale_factor_volume_scatter,3.269e-06,Multiplier [m^-1 sr^-1 counts^-1]
 BBFL2W-1156,CC_scattering_angle,124,Optical backscatter scattering angle [degrees].

--- a/calibration/FLORTJ/CGINS-FLORTJ-01156__20170525.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01156__20170525.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1156,CC_dark_counts_cdom,46,date in filename comes from factory characterization sheet
-BBFL2W-1156,CC_scale_factor_cdom,0.0764,
+BBFL2W-1156,CC_scale_factor_cdom,0.12297,Original scale factor (0.07640) corrected by Sea-Bird with the new value of 0.12297 = 0.07640 * 5.62 * 0.28639
 BBFL2W-1156,CC_dark_counts_chlorophyll_a,50,
 BBFL2W-1156,CC_scale_factor_chlorophyll_a,0.0121,
 BBFL2W-1156,CC_dark_counts_volume_scatter,53,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01156__20201215.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01156__20201215.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1156,CC_dark_counts_cdom,48,date in filename comes from dev file
-BBFL2W-1156,CC_scale_factor_cdom,0.0744,
+BBFL2W-1156,CC_scale_factor_cdom,0.31703,Original scale factor (0.07440) corrected by Sea-Bird with the new value of 0.31703 = 0.07440 * 5.62 * 0.75821
 BBFL2W-1156,CC_dark_counts_chlorophyll_a,56,
 BBFL2W-1156,CC_scale_factor_chlorophyll_a,0.0118,
 BBFL2W-1156,CC_dark_counts_volume_scatter,51,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01156__20220524.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01156__20220524.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1156,CC_dark_counts_cdom,49,date in filename comes from dev file
-BBFL2W-1156,CC_scale_factor_cdom,9.145E-02,
+BBFL2W-1156,CC_scale_factor_cdom,0.38968,Original scale factor (0.09145) corrected by Sea-Bird with the new value of 0.38968 = 0.09145 * 5.62 * 0.75821
 BBFL2W-1156,CC_dark_counts_chlorophyll_a,51,
 BBFL2W-1156,CC_scale_factor_chlorophyll_a,1.151E-02,
 BBFL2W-1156,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01206__20140530.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01206__20140530.csv
@@ -5,7 +5,7 @@ BBFL2W-1206,CC_dark_counts_chlorophyll_a,51,Measured signal output of fluormeter
 BBFL2W-1206,CC_dark_counts_volume_scatter,50,Measured signal output of fluormeter in clean water with black tape over the detector [counts]
 BBFL2W-1206,CC_depolarization_ratio,0.039,Depolarization ratio [unitless].
 BBFL2W-1206,CC_measurement_wavelength,700,Optical backscatter measurement wavelength [nm].
-BBFL2W-1206,CC_scale_factor_cdom,0.0905,Multiplier [ppb counts^-1]
+BBFL2W-1206,CC_scale_factor_cdom,0.11276,Original scale factor (0.09050) corrected by Sea-Bird with the new value of 0.11276 = 0.09050 * 5.62 * 0.22169
 BBFL2W-1206,CC_scale_factor_chlorophyll_a,0.0121,Multiplier [ug L^-1 counts^-1]
 BBFL2W-1206,CC_scale_factor_volume_scatter,3.012e-06,Multiplier [m^-1 sr^-1 counts^-1]
 BBFL2W-1206,CC_scattering_angle,124,Optical backscatter scattering angle [degrees].

--- a/calibration/FLORTJ/CGINS-FLORTJ-01206__20160412.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01206__20160412.csv
@@ -5,7 +5,7 @@ BBFL2W-1206,CC_dark_counts_chlorophyll_a,48,Measured signal output of fluoromete
 BBFL2W-1206,CC_dark_counts_volume_scatter,48,Measured signal output of scatterometer in clean water with black tape over the detector [counts]
 BBFL2W-1206,CC_depolarization_ratio,0.039,Depolarization ratio [unitless].
 BBFL2W-1206,CC_measurement_wavelength,700,Optical backscatter measurement wavelength [nm].
-BBFL2W-1206,CC_scale_factor_cdom,0.0832,Multiplier [ppb counts^-1]
+BBFL2W-1206,CC_scale_factor_cdom,0.13391,Original scale factor (0.08320) corrected by Sea-Bird with the new value of 0.13391 = 0.08320 * 5.62 * 0.28639
 BBFL2W-1206,CC_scale_factor_chlorophyll_a,0.0118,Multiplier [ug L^-1 counts^-1]
 BBFL2W-1206,CC_scale_factor_volume_scatter,2.917e-06,Multiplier [m^-1 sr^-1 counts^-1]
 BBFL2W-1206,CC_scattering_angle,124,Optical backscatter scattering angle [degrees].

--- a/calibration/FLORTJ/CGINS-FLORTJ-01206__20161115.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01206__20161115.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1206,CC_dark_counts_cdom,46,date in filename comes from factory characterization sheet
-BBFL2W-1206,CC_scale_factor_cdom,0.0888,
+BBFL2W-1206,CC_scale_factor_cdom,0.14293,Original scale factor (0.08880) corrected by Sea-Bird with the new value of 0.14293 = 0.08880 * 5.62 * 0.28639
 BBFL2W-1206,CC_dark_counts_chlorophyll_a,50,
 BBFL2W-1206,CC_scale_factor_chlorophyll_a,.0121,
 BBFL2W-1206,CC_dark_counts_volume_scatter,49,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01206__20181212.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01206__20181212.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1206,CC_dark_counts_cdom,52,date in filename comes from dev file
-BBFL2W-1206,CC_scale_factor_cdom,0.0921,
+BBFL2W-1206,CC_scale_factor_cdom,0.14824,Original scale factor (0.09210) corrected by Sea-Bird with the new value of 0.14824 = 0.09210 * 5.62 * 0.28639
 BBFL2W-1206,CC_dark_counts_chlorophyll_a,55,
 BBFL2W-1206,CC_scale_factor_chlorophyll_a,0.0122,
 BBFL2W-1206,CC_dark_counts_volume_scatter,51,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01206__20200304.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01206__20200304.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1206,CC_dark_counts_cdom,47,date in filename comes from dev file
-BBFL2W-1206,CC_scale_factor_cdom,0.0719,
+BBFL2W-1206,CC_scale_factor_cdom,0.30638,Original scale factor (0.07190) corrected by Sea-Bird with the new value of 0.30638 = 0.07190 * 5.62 * 0.75821
 BBFL2W-1206,CC_dark_counts_chlorophyll_a,50,
 BBFL2W-1206,CC_scale_factor_chlorophyll_a,0.0123,
 BBFL2W-1206,CC_dark_counts_volume_scatter,51,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01206__20220713.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01206__20220713.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1206,CC_dark_counts_cdom,48,date in filename comes from dev file
-BBFL2W-1206,CC_scale_factor_cdom,9.131E-02,
+BBFL2W-1206,CC_scale_factor_cdom,0.38909,Original scale factor (0.09131) corrected by Sea-Bird with the new value of 0.38909 = 0.09131 * 5.62 * 0.75821
 BBFL2W-1206,CC_dark_counts_chlorophyll_a,47,
 BBFL2W-1206,CC_scale_factor_chlorophyll_a,1.204E-02,
 BBFL2W-1206,CC_dark_counts_volume_scatter,46,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01207__20140530.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01207__20140530.csv
@@ -5,7 +5,7 @@ BBFL2W-1207,CC_dark_counts_chlorophyll_a,50,Measured signal output of fluormeter
 BBFL2W-1207,CC_dark_counts_volume_scatter,46,Measured signal output of fluormeter in clean water with black tape over the detector [counts]
 BBFL2W-1207,CC_depolarization_ratio,0.039,Depolarization ratio [unitless].
 BBFL2W-1207,CC_measurement_wavelength,700,Optical backscatter measurement wavelength [nm].
-BBFL2W-1207,CC_scale_factor_cdom,0.0904,Multiplier [ppb counts^-1]
+BBFL2W-1207,CC_scale_factor_cdom,0.11263,Original scale factor (0.09040) corrected by Sea-Bird with the new value of 0.11263 = 0.09040 * 5.62 * 0.22169
 BBFL2W-1207,CC_scale_factor_chlorophyll_a,0.0121,Multiplier [ug L^-1 counts^-1]
 BBFL2W-1207,CC_scale_factor_volume_scatter,3.016E-06,Multiplier [m^-1 sr^-1 counts^-1]
 BBFL2W-1207,CC_scattering_angle,124,Optical backscatter scattering angle [degrees].

--- a/calibration/FLORTJ/CGINS-FLORTJ-01207__20160714.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01207__20160714.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1207,CC_dark_counts_cdom,46,date in filename comes from factory characterization sheet
-BBFL2W-1207,CC_scale_factor_cdom,0.0874,
+BBFL2W-1207,CC_scale_factor_cdom,0.14067,Original scale factor (0.08740) corrected by Sea-Bird with the new value of 0.14067 = 0.08740 * 5.62 * 0.28639
 BBFL2W-1207,CC_dark_counts_chlorophyll_a,54,
 BBFL2W-1207,CC_scale_factor_chlorophyll_a,.0122,
 BBFL2W-1207,CC_dark_counts_volume_scatter,51,not 61 as in devfile

--- a/calibration/FLORTJ/CGINS-FLORTJ-01207__20180126.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01207__20180126.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1207,CC_dark_counts_cdom,45,date in filename comes from dev file
-BBFL2W-1207,CC_scale_factor_cdom,0.0877,
+BBFL2W-1207,CC_scale_factor_cdom,0.14116,Original scale factor (0.08770) corrected by Sea-Bird with the new value of 0.14116 = 0.08770 * 5.62 * 0.28639
 BBFL2W-1207,CC_dark_counts_chlorophyll_a,49,
 BBFL2W-1207,CC_scale_factor_chlorophyll_a,.0128,
 BBFL2W-1207,CC_dark_counts_volume_scatter,52,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01207__20210322.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01207__20210322.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1207,CC_dark_counts_cdom,42,date in filename comes from dev file
-BBFL2W-1207,CC_scale_factor_cdom,8.000E-02,
+BBFL2W-1207,CC_scale_factor_cdom,0.34089,Original scale factor (0.08000) corrected by Sea-Bird with the new value of 0.34089 = 0.08000 * 5.62 * 0.75821
 BBFL2W-1207,CC_dark_counts_chlorophyll_a,49,
 BBFL2W-1207,CC_scale_factor_chlorophyll_a,1.210E-02,
 BBFL2W-1207,CC_dark_counts_volume_scatter,53,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01207__20211020.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01207__20211020.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1207,CC_dark_counts_cdom,48,date in filename comes from dev file
-BBFL2W-1207,CC_scale_factor_cdom,9.970E-02,
+BBFL2W-1207,CC_scale_factor_cdom,0.42484,Original scale factor (0.09970) corrected by Sea-Bird with the new value of 0.42484 = 0.09970 * 5.62 * 0.75821
 BBFL2W-1207,CC_dark_counts_chlorophyll_a,56,
 BBFL2W-1207,CC_scale_factor_chlorophyll_a,1.130E-02,
 BBFL2W-1207,CC_dark_counts_volume_scatter,53,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01518__20161205.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01518__20161205.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1518,CC_dark_counts_cdom,48,date in filename comes from factory characterization sheet
-BBFL2W-1518,CC_scale_factor_cdom,0.0909,
+BBFL2W-1518,CC_scale_factor_cdom,0.14631,Original scale factor (0.09090) corrected by Sea-Bird with the new value of 0.14631 = 0.09090 * 5.62 * 0.28639
 BBFL2W-1518,CC_dark_counts_chlorophyll_a,51,
 BBFL2W-1518,CC_scale_factor_chlorophyll_a,.0122,
 BBFL2W-1518,CC_dark_counts_volume_scatter,51,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01518__20180126.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01518__20180126.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1518,CC_dark_counts_cdom,48,date in filename comes from dev file
-BBFL2W-1518,CC_scale_factor_cdom,0.0886,
+BBFL2W-1518,CC_scale_factor_cdom,0.14260,Original scale factor (0.08860) corrected by Sea-Bird with the new value of 0.14260 = 0.08860 * 5.62 * 0.28639
 BBFL2W-1518,CC_dark_counts_chlorophyll_a,47,
 BBFL2W-1518,CC_scale_factor_chlorophyll_a,.0124,
 BBFL2W-1518,CC_dark_counts_volume_scatter,49,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01518__20210122.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01518__20210122.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1518,CC_dark_counts_cdom,50,date in filename comes from dev file
-BBFL2W-1518,CC_scale_factor_cdom,0.1041,
+BBFL2W-1518,CC_scale_factor_cdom,0.44359,Original scale factor (0.10410) corrected by Sea-Bird with the new value of 0.44359 = 0.10410 * 5.62 * 0.75821
 BBFL2W-1518,CC_dark_counts_chlorophyll_a,48,
 BBFL2W-1518,CC_scale_factor_chlorophyll_a,.0117,
 BBFL2W-1518,CC_dark_counts_volume_scatter,49,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01518__20211115.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01518__20211115.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1518,CC_dark_counts_cdom,50,date in filename comes from dev file
-BBFL2W-1518,CC_scale_factor_cdom,0.0908,
+BBFL2W-1518,CC_scale_factor_cdom,0.38691,Original scale factor (0.09080) corrected by Sea-Bird with the new value of 0.38691 = 0.09080 * 5.62 * 0.75821
 BBFL2W-1518,CC_dark_counts_chlorophyll_a,50,
 BBFL2W-1518,CC_scale_factor_chlorophyll_a,.0121,
 BBFL2W-1518,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01518__20220812.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01518__20220812.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1518,CC_dark_counts_cdom,50,date in filename comes from dev file
-BBFL2W-1518,CC_scale_factor_cdom,9.298E-02,
+BBFL2W-1518,CC_scale_factor_cdom,0.39620,Original scale factor (0.09298) corrected by Sea-Bird with the new value of 0.39620 = 0.09298 * 5.62 * 0.75821
 BBFL2W-1518,CC_dark_counts_chlorophyll_a,54,
 BBFL2W-1518,CC_scale_factor_chlorophyll_a,1.217E-02,
 BBFL2W-1518,CC_dark_counts_volume_scatter,54,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01519__20161221.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01519__20161221.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1519,CC_dark_counts_cdom,49,date in filename comes from factory characterization sheet
-BBFL2W-1519,CC_scale_factor_cdom,0.0909,
+BBFL2W-1519,CC_scale_factor_cdom,0.14631,Original scale factor (0.09090) corrected by Sea-Bird with the new value of 0.14631 = 0.09090 * 5.62 * 0.28639
 BBFL2W-1519,CC_dark_counts_chlorophyll_a,48,
 BBFL2W-1519,CC_scale_factor_chlorophyll_a,.0122,
 BBFL2W-1519,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01519__20180131.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01519__20180131.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1519,CC_dark_counts_cdom,48,date in filename comes from dev file
-BBFL2W-1519,CC_scale_factor_cdom,0.0959,
+BBFL2W-1519,CC_scale_factor_cdom,0.15435,Original scale factor (0.09590) corrected by Sea-Bird with the new value of 0.15435 = 0.09590 * 5.62 * 0.28639
 BBFL2W-1519,CC_dark_counts_chlorophyll_a,47,
 BBFL2W-1519,CC_scale_factor_chlorophyll_a,.0120,
 BBFL2W-1519,CC_dark_counts_volume_scatter,50,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01519__20200117.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01519__20200117.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1519,CC_dark_counts_cdom,48,date in filename comes from dev file
-BBFL2W-1519,CC_scale_factor_cdom,0.0904,
+BBFL2W-1519,CC_scale_factor_cdom,0.22646,Original scale factor (0.09040) corrected by Sea-Bird with the new value of 0.22646 = 0.09040 * 5.62 * 0.44575
 BBFL2W-1519,CC_dark_counts_chlorophyll_a,48,
 BBFL2W-1519,CC_scale_factor_chlorophyll_a,.0112,
 BBFL2W-1519,CC_dark_counts_volume_scatter,51,

--- a/calibration/FLORTJ/CGINS-FLORTJ-01519__20221107.csv
+++ b/calibration/FLORTJ/CGINS-FLORTJ-01519__20221107.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 BBFL2W-1519,CC_dark_counts_cdom,49,date in filename comes from dev file
-BBFL2W-1519,CC_scale_factor_cdom,8.896E-02,
+BBFL2W-1519,CC_scale_factor_cdom,0.37907,Original scale factor (0.08896) corrected by Sea-Bird with the new value of 0.37907 = 0.08896 * 5.62 * 0.75821
 BBFL2W-1519,CC_dark_counts_chlorophyll_a,49,
 BBFL2W-1519,CC_scale_factor_chlorophyll_a,1.147E-02,
 BBFL2W-1519,CC_dark_counts_volume_scatter,53,

--- a/calibration/FLORTK/CGINS-FLORTK-01030__20121211.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01030__20121211.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1030,CC_dark_counts_volume_scatter,50.0,
 1030,CC_depolarization_ratio,0.039,
 1030,CC_measurement_wavelength,700.0,
-1030,CC_scale_factor_cdom,0.0904,
+1030,CC_scale_factor_cdom,0.15096,Original scale factor (0.09040) corrected by Sea-Bird with the new value of 0.15096 = 0.09040 * 5.62 * 0.29713
 1030,CC_scale_factor_chlorophyll_a,0.0121,
 1030,CC_scale_factor_volume_scatter,3.481e-06,
 1030,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01030__20141204.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01030__20141204.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1030,CC_dark_counts_volume_scatter,48.0,
 1030,CC_depolarization_ratio,0.039,
 1030,CC_measurement_wavelength,700.0,
-1030,CC_scale_factor_cdom,0.0831,
+1030,CC_scale_factor_cdom,0.10354,Original scale factor (0.08310) corrected by Sea-Bird with the new value of 0.10354 = 0.08310 * 5.62 * 0.22169
 1030,CC_scale_factor_chlorophyll_a,0.0119,
 1030,CC_scale_factor_volume_scatter,3.233e-06,
 1030,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01030__20151216.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01030__20151216.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1030,CC_dark_counts_volume_scatter,48.0,
 1030,CC_depolarization_ratio,0.039,
 1030,CC_measurement_wavelength,700.0,
-1030,CC_scale_factor_cdom,0.0699,
+1030,CC_scale_factor_cdom,0.11251,Original scale factor (0.06990) corrected by Sea-Bird with the new value of 0.11251 = 0.06990 * 5.62 * 0.28639
 1030,CC_scale_factor_chlorophyll_a,0.0121,
 1030,CC_scale_factor_volume_scatter,3.308e-06,
 1030,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01030__20161206.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01030__20161206.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1030,CC_dark_counts_cdom,47,date in filename comes from factory characterization sheet
-1030,CC_scale_factor_cdom,0.0650,
+1030,CC_scale_factor_cdom,0.10462,Original scale factor (0.06500) corrected by Sea-Bird with the new value of 0.10462 = 0.06500 * 5.62 * 0.28639
 1030,CC_dark_counts_chlorophyll_a,47,
 1030,CC_scale_factor_chlorophyll_a,0.0116,
 1030,CC_dark_counts_volume_scatter,48,

--- a/calibration/FLORTK/CGINS-FLORTK-01032__20121212.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01032__20121212.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1032,CC_dark_counts_volume_scatter,50.0,
 1032,CC_depolarization_ratio,0.039,
 1032,CC_measurement_wavelength,700.0,
-1032,CC_scale_factor_cdom,0.0908,
+1032,CC_scale_factor_cdom,0.15162,Original scale factor (0.09080) corrected by Sea-Bird with the new value of 0.15162 = 0.09080 * 5.62 * 0.29713
 1032,CC_scale_factor_chlorophyll_a,0.0121,
 1032,CC_scale_factor_volume_scatter,3.482e-06,
 1032,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01032__20150707.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01032__20150707.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1032,CC_dark_counts_volume_scatter,48.0,
 1032,CC_depolarization_ratio,0.039,
 1032,CC_measurement_wavelength,700.0,
-1032,CC_scale_factor_cdom,0.0813,
+1032,CC_scale_factor_cdom,0.13085,Original scale factor (0.08130) corrected by Sea-Bird with the new value of 0.13085 = 0.08130 * 5.62 * 0.28639
 1032,CC_scale_factor_chlorophyll_a,0.0121,
 1032,CC_scale_factor_volume_scatter,3.288e-06,
 1032,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01032__20160715.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01032__20160715.csv
@@ -5,7 +5,7 @@ serial,name,value,notes
 1032,CC_dark_counts_volume_scatter,48.0,
 1032,CC_depolarization_ratio,0.039,
 1032,CC_measurement_wavelength,700.0,
-1032,CC_scale_factor_cdom,0.0726,
+1032,CC_scale_factor_cdom,0.11685,Original scale factor (0.07260) corrected by Sea-Bird with the new value of 0.11685 = 0.07260 * 5.62 * 0.28639
 1032,CC_scale_factor_chlorophyll_a,0.0118,
 1032,CC_scale_factor_volume_scatter,3.414e-06,
 1032,CC_scattering_angle,124.0,

--- a/calibration/FLORTK/CGINS-FLORTK-01602__20170706.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01602__20170706.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1602,CC_dark_counts_cdom,49,date in filename comes from factory characterization sheet
-1602,CC_scale_factor_cdom,0.0905,
+1602,CC_scale_factor_cdom,0.14566,Original scale factor (0.09050) corrected by Sea-Bird with the new value of 0.14566 = 0.09050 * 5.62 * 0.28639
 1602,CC_dark_counts_chlorophyll_a,47,
 1602,CC_scale_factor_chlorophyll_a,0.0125,
 1602,CC_dark_counts_volume_scatter,49,

--- a/calibration/FLORTK/CGINS-FLORTK-01602__20180628.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01602__20180628.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1602,CC_dark_counts_cdom,50,date in filename comes from characterization sheet
-1602,CC_scale_factor_cdom,0.0818,
+1602,CC_scale_factor_cdom,0.13166,Original scale factor (0.08180) corrected by Sea-Bird with the new value of 0.13166 = 0.08180 * 5.62 * 0.28639
 1602,CC_dark_counts_chlorophyll_a,48,
 1602,CC_scale_factor_chlorophyll_a,0.0111,
 1602,CC_dark_counts_volume_scatter,49,

--- a/calibration/FLORTK/CGINS-FLORTK-01602__20190620.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01602__20190620.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1602,CC_dark_counts_cdom,50,date in filename comes from dev file
-1602,CC_scale_factor_cdom,0.0761,
+1602,CC_scale_factor_cdom,0.19064,Original scale factor (0.07610) corrected by Sea-Bird with the new value of 0.19064 = 0.07610 * 5.62 * 0.44575
 1602,CC_dark_counts_chlorophyll_a,46,
 1602,CC_scale_factor_chlorophyll_a,0.0123,
 1602,CC_dark_counts_volume_scatter,49,

--- a/calibration/FLORTK/CGINS-FLORTK-01602__20200831.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01602__20200831.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1602,CC_dark_counts_cdom,50,date in filename comes from dev file
-1602,CC_scale_factor_cdom,0.0896,
+1602,CC_scale_factor_cdom,0.38180,Original scale factor (0.08960) corrected by Sea-Bird with the new value of 0.38180 = 0.08960 * 5.62 * 0.75821
 1602,CC_dark_counts_chlorophyll_a,45,
 1602,CC_scale_factor_chlorophyll_a,0.0121,
 1602,CC_dark_counts_volume_scatter,48,

--- a/calibration/FLORTK/CGINS-FLORTK-01602__20211108.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01602__20211108.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1602,CC_dark_counts_cdom,50,date in filename comes from dev file
-1602,CC_scale_factor_cdom,0.0767,
+1602,CC_scale_factor_cdom,0.32683,Original scale factor (0.07670) corrected by Sea-Bird with the new value of 0.32683 = 0.07670 * 5.62 * 0.75821
 1602,CC_dark_counts_chlorophyll_a,48,
 1602,CC_scale_factor_chlorophyll_a,0.0117,
 1602,CC_dark_counts_volume_scatter,47,

--- a/calibration/FLORTK/CGINS-FLORTK-01602__20221101.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01602__20221101.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1602,CC_dark_counts_cdom,50,date in filename comes from dev file
-1602,CC_scale_factor_cdom,8.723E-02,
+1602,CC_scale_factor_cdom,0.37170,Original scale factor (0.08723) corrected by Sea-Bird with the new value of 0.37170 = 0.08723 * 5.62 * 0.75821
 1602,CC_dark_counts_chlorophyll_a,47,
 1602,CC_scale_factor_chlorophyll_a,1.202E-02,
 1602,CC_dark_counts_volume_scatter,48,

--- a/calibration/FLORTK/CGINS-FLORTK-01707__20180605.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01707__20180605.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1707,CC_dark_counts_cdom,49,date in filename comes from dev file
-1707,CC_scale_factor_cdom,0.0913,
+1707,CC_scale_factor_cdom,0.14695,Original scale factor (0.09130) corrected by Sea-Bird with the new value of 0.14695 = 0.09130 * 5.62 * 0.28639
 1707,CC_dark_counts_chlorophyll_a,49,
 1707,CC_scale_factor_chlorophyll_a,0.0121,
 1707,CC_dark_counts_volume_scatter,48,

--- a/calibration/FLORTK/CGINS-FLORTK-01707__20191210.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01707__20191210.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1707,CC_dark_counts_cdom,50,date in filename comes from dev file
-1707,CC_scale_factor_cdom,0.0895,
+1707,CC_scale_factor_cdom,0.22421,Original scale factor (0.08950) corrected by Sea-Bird with the new value of 0.22421 = 0.08950 * 5.62 * 0.44575
 1707,CC_dark_counts_chlorophyll_a,50,
 1707,CC_scale_factor_chlorophyll_a,0.0116,
 1707,CC_dark_counts_volume_scatter,49,

--- a/calibration/FLORTK/CGINS-FLORTK-01707__20210622.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01707__20210622.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1707,CC_dark_counts_cdom,49,date in filename comes from dev file
-1707,CC_scale_factor_cdom,0.0725,
+1707,CC_scale_factor_cdom,0.30893,Original scale factor (0.07250) corrected by Sea-Bird with the new value of 0.30893 = 0.07250 * 5.62 * 0.75821
 1707,CC_dark_counts_chlorophyll_a,49,
 1707,CC_scale_factor_chlorophyll_a,0.0112,
 1707,CC_dark_counts_volume_scatter,48,

--- a/calibration/FLORTK/CGINS-FLORTK-01707__20220513.csv
+++ b/calibration/FLORTK/CGINS-FLORTK-01707__20220513.csv
@@ -1,6 +1,6 @@
 serial,name,value,notes
 1707,CC_dark_counts_cdom,50,date in filename comes from dev file
-1707,CC_scale_factor_cdom,9.231E-02,
+1707,CC_scale_factor_cdom,0.39335,Original scale factor (0.09231) corrected by Sea-Bird with the new value of 0.39335 = 0.09231 * 5.62 * 0.75821
 1707,CC_dark_counts_chlorophyll_a,50,
 1707,CC_scale_factor_chlorophyll_a,1.154E-02,
 1707,CC_dark_counts_volume_scatter,49,


### PR DESCRIPTION
Adjusts the CDOM scale factor for Endurance Array ECO Triplet sensors (sans those used on gliders) in response to the incorrect primary standard and in-situ bias issues identified by Sea-Bird Scientific (see attachment: [SBS_CDOM_Customer_Notice_-_NOVEMBER[23].pdf](https://github.com/user-attachments/files/20842901/SBS_CDOM_Customer_Notice_-_NOVEMBER.23.pdf)).

The new scale factors are calculated by multiplying the original scale factor by the incorrect primary standard correction of 5.62 and the in-situ bias correction factor (variable over time). A note is added to each file where the update was made indicating the original scale factor and the newly calculated value.