### PR TITLE
Removes the CDOM correction factor from FLORT-O

### DIFF
--- a/calibration/FLORTO/CGINS-FLORTO-01239__20140731.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01239__20140731.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1239,CC_depolarization_ratio,0.039,
 1239,CC_measurement_wavelength,700.0,
 1239,CC_scattering_angle,124.0,
-1239,CC_cdom_correction_factor,1.245926,Sea-Bird provided CDOM correction factor: 1.245926 = 5.62 * 0.221695

--- a/calibration/FLORTO/CGINS-FLORTO-01239__20170706.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01239__20170706.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1239,CC_depolarization_ratio,0.039,
 1239,CC_measurement_wavelength,700.0,
 1239,CC_scattering_angle,124.0,
-1239,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01239__20200310.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01239__20200310.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1239,CC_depolarization_ratio,0.039,
 1239,CC_measurement_wavelength,700.0,
 1239,CC_scattering_angle,124.0,
-1239,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTO/CGINS-FLORTO-01239__20220126.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01239__20220126.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1239,CC_depolarization_ratio,0.039,
 1239,CC_measurement_wavelength,700.0,
 1239,CC_scattering_angle,124.0,
-1239,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTO/CGINS-FLORTO-01240__20140731.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01240__20140731.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1240,CC_depolarization_ratio,0.039,
 1240,CC_measurement_wavelength,700,
 1240,CC_scattering_angle,124,
-1240,CC_cdom_correction_factor,1.245926,Sea-Bird provided CDOM correction factor: 1.245926 = 5.62 * 0.221695

--- a/calibration/FLORTO/CGINS-FLORTO-01329__20150624.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01329__20150624.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1329,CC_depolarization_ratio,0.039,
 1329,CC_measurement_wavelength,700,
 1329,CC_scattering_angle,124,
-1329,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01330__20151124.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01330__20151124.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1330,CC_depolarization_ratio,0.039,
 1330,CC_measurement_wavelength,700,
 1330,CC_scattering_angle,124,
-1330,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01330__20190913.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01330__20190913.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1330,CC_depolarization_ratio,0.039,
 1330,CC_measurement_wavelength,700,
 1330,CC_scattering_angle,124,
-1330,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTO/CGINS-FLORTO-01331__20150624.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01331__20150624.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1331,CC_depolarization_ratio,0.039,
 1331,CC_measurement_wavelength,700,
 1331,CC_scattering_angle,124,
-1331,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01331__20210729.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01331__20210729.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1331,CC_depolarization_ratio,0.039,
 1331,CC_measurement_wavelength,700,
 1331,CC_scattering_angle,124,
-1331,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTO/CGINS-FLORTO-01332__20151220.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01332__20151220.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1332,CC_depolarization_ratio,0.039,
 1332,CC_measurement_wavelength,700,
 1332,CC_scattering_angle,124,
-1332,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01332__20190327.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01332__20190327.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1332,CC_depolarization_ratio,0.039,
 1332,CC_measurement_wavelength,700,
 1332,CC_scattering_angle,124,
-1332,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01332__20220329.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01332__20220329.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1332,CC_depolarization_ratio,0.039,
 1332,CC_measurement_wavelength,700,
 1332,CC_scattering_angle,124,
-1332,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTO/CGINS-FLORTO-01333__20151220.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01333__20151220.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1333,CC_depolarization_ratio,0.039,
 1333,CC_measurement_wavelength,700,
 1333,CC_scattering_angle,124,
-1333,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01333__20190327.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01333__20190327.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1333,CC_depolarization_ratio,0.039,
 1333,CC_measurement_wavelength,700,
 1333,CC_scattering_angle,124,
-1333,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01333__20250103.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01333__20250103.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1333,CC_depolarization_ratio,0.039,
 1333,CC_measurement_wavelength,700,
 1333,CC_scattering_angle,124,
-1333,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTO/CGINS-FLORTO-01342__20150924.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01342__20150924.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1342,CC_depolarization_ratio,0.039,
 1342,CC_measurement_wavelength,700,
 1342,CC_scattering_angle,124,
-1342,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01342__20201015.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01342__20201015.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1342,CC_depolarization_ratio,0.039,
 1342,CC_measurement_wavelength,700,
 1342,CC_scattering_angle,124,
-1342,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTO/CGINS-FLORTO-01342__20220307.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01342__20220307.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1342,CC_depolarization_ratio,0.039,
 1342,CC_measurement_wavelength,700,
 1342,CC_scattering_angle,124,
-1342,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTO/CGINS-FLORTO-01343__20150923.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01343__20150923.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1343,CC_depolarization_ratio,0.039,
 1343,CC_measurement_wavelength,700,
 1343,CC_scattering_angle,124,
-1343,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01344__20150914.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01344__20150914.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1344,CC_depolarization_ratio,0.039,
 1344,CC_measurement_wavelength,700,
 1344,CC_scattering_angle,124,
-1344,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01345__20150914.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01345__20150914.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1345,CC_depolarization_ratio,0.039,
 1345,CC_measurement_wavelength,700,
 1345,CC_scattering_angle,124,
-1345,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01346__20150914.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01346__20150914.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1346,CC_depolarization_ratio,0.039,
 1346,CC_measurement_wavelength,700,
 1346,CC_scattering_angle,124,
-1346,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01347__20140916.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01347__20140916.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1347,CC_depolarization_ratio,0.039,
 1347,CC_measurement_wavelength,700,
 1347,CC_scattering_angle,124,
-1347,CC_cdom_correction_factor,1.245926,Sea-Bird provided CDOM correction factor: 1.245926 = 5.62 * 0.221695

--- a/calibration/FLORTO/CGINS-FLORTO-01347__20200306.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01347__20200306.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1347,CC_depolarization_ratio,0.039,
 1347,CC_measurement_wavelength,700,
 1347,CC_scattering_angle,124,
-1347,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTO/CGINS-FLORTO-01347__20220802.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01347__20220802.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1347,CC_depolarization_ratio,0.039,
 1347,CC_measurement_wavelength,700,
 1347,CC_scattering_angle,124,
-1347,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTO/CGINS-FLORTO-01348__20150923.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01348__20150923.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1348,CC_depolarization_ratio,0.039,
 1348,CC_measurement_wavelength,700,
 1348,CC_scattering_angle,124,
-1348,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-01348__20190708.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01348__20190708.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1348,CC_depolarization_ratio,0.039,
 1348,CC_measurement_wavelength,700,
 1348,CC_scattering_angle,124,
-1348,CC_cdom_correction_factor,2.505136,Sea-Bird provided CDOM correction factor: 2.505136 = 5.62 * 0.445754

--- a/calibration/FLORTO/CGINS-FLORTO-01348__20210715.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01348__20210715.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1348,CC_depolarization_ratio,0.039,
 1348,CC_measurement_wavelength,700,
 1348,CC_scattering_angle,124,
-1348,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213

--- a/calibration/FLORTO/CGINS-FLORTO-01348__20231227.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01348__20231227.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1348,CC_depolarization_ratio,0.039,
 1348,CC_measurement_wavelength,700,
 1348,CC_scattering_angle,124,
-1348,CC_cdom_correction_factor,1.000000,No Sea-Bird CDOM correction factor applied.

--- a/calibration/FLORTO/CGINS-FLORTO-01349__20150925.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-01349__20150925.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 1349,CC_depolarization_ratio,0.039,
 1349,CC_measurement_wavelength,700,
 1349,CC_scattering_angle,124,
-1349,CC_cdom_correction_factor,1.609525,Sea-Bird provided CDOM correction factor: 1.609525 = 5.62 * 0.286392

--- a/calibration/FLORTO/CGINS-FLORTO-07929__20221128.csv
+++ b/calibration/FLORTO/CGINS-FLORTO-07929__20221128.csv
@@ -3,4 +3,3 @@ serial,name,value,notes
 7929,CC_depolarization_ratio,0.039,
 7929,CC_measurement_wavelength,700.0,
 7929,CC_scattering_angle,124.0,
-7929,CC_cdom_correction_factor,4.261157,Sea-Bird provided CDOM correction factor: 4.261157 = 5.62 * 0.758213


### PR DESCRIPTION
Eric Rehm at SeaBird incorrectly provided CDOM correction factors for the FLORT-O instruments, which do not measure CDOM, but instead are BB3 instruments which measure 3 different wavelengths of backscatter.

This pull request removes the unnecessary CDOM correction factors from the FLORT-O calibration CSV files.